### PR TITLE
badge: Fix 'download_filie' -> 'download_file' typo

### DIFF
--- a/openbadgeslib/badge.py
+++ b/openbadgeslib/badge.py
@@ -184,7 +184,7 @@ class Badge():
                 error = True
 
         try:
-            data = download_filie(self.criteria_url)
+            data = download_file(self.criteria_url)
         except:
             pass
         finally:


### PR DESCRIPTION
Typo was introduced in 68b1531c (Version update to v0.4.2, 2015-12-20).