### PR TITLE
fix(jws): make JWS exceptions inherit LibOpenBadgesException

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -4,6 +4,14 @@ OpenBadgesLib - Changelog
 Newest first. Dates are ISO 8601 (YYYY-MM-DD).
 
 
+* Unreleased
+
+  - fix: JWS header parsing (verify_block) now wraps malformed/non-object
+    headers into SignatureError instead of leaking a raw json.JSONDecodeError,
+    and every openbadgeslib._jws exception now inherits from
+    LibOpenBadgesException so it can no longer escape verify()/sign() uncaught.
+
+
 * v1.1.5 - 2026-06-30
 
   - SECURITY: generated private key files are now created with exclusive writes

--- a/openbadgeslib/_jws/__init__.py
+++ b/openbadgeslib/_jws/__init__.py
@@ -77,7 +77,13 @@ def verify_block(msg: Union[str, bytes], key: Optional[Any] = None) -> bool:
     if key is None:
         raise MissingKey("No verification key provided")
 
-    header = utils.decode(head_b64)
+    try:
+        header = utils.decode(head_b64)
+    except (ValueError, TypeError) as exc:
+        raise SignatureError("Malformed JWS header") from exc
+    if not isinstance(header, dict):
+        raise SignatureError("Malformed JWS header")
+
     alg_name = header.get('alg')
     if not alg_name:
         raise MissingVerifier("JWS header is missing 'alg'")

--- a/openbadgeslib/_jws/exceptions.py
+++ b/openbadgeslib/_jws/exceptions.py
@@ -1,18 +1,25 @@
-class MissingKey(Exception):
+from ..errors import LibOpenBadgesException
+
+
+class JWSException(LibOpenBadgesException):
     pass
 
 
-class MissingSigner(Exception):
+class MissingKey(JWSException):
     pass
 
 
-class MissingVerifier(Exception):
+class MissingSigner(JWSException):
     pass
 
 
-class SignatureError(Exception):
+class MissingVerifier(JWSException):
     pass
 
 
-class RouteMissingError(Exception):
+class SignatureError(JWSException):
+    pass
+
+
+class RouteMissingError(JWSException):
     pass

--- a/tests/test_jws.py
+++ b/tests/test_jws.py
@@ -5,7 +5,7 @@ import pytest
 from openbadgeslib._jws import sign, verify_block
 from openbadgeslib._jws import utils
 from openbadgeslib._jws.exceptions import (
-    SignatureError, RouteMissingError, MissingKey, MissingSigner,
+    SignatureError, RouteMissingError, MissingKey, MissingSigner, MissingVerifier,
 )
 
 
@@ -125,6 +125,33 @@ class TestVerifyBlockEdgeCases:
         jws = _build_jws({'alg': 'RS256'}, PAYLOAD, raw_sig)
         with pytest.raises(MissingKey):
             verify_block(jws, key=None)
+
+    def test_non_json_header_raises_signature_error(self, rsa_pub_pem):
+        """A base64url-valid but non-JSON header must not leak json.JSONDecodeError."""
+        from openbadgeslib.keys import KeyRSA
+        k = KeyRSA()
+        k.read_public_key(rsa_pub_pem)
+        bad_header = utils.to_base64(b'not-json-at-all')
+        jws = bad_header + b'.' + utils.encode(PAYLOAD) + b'.' + utils.to_base64(b'sig')
+        with pytest.raises(SignatureError):
+            verify_block(jws, key=k.get_pub_key())
+
+    def test_non_dict_header_raises_signature_error(self, rsa_pub_pem):
+        """A header that decodes to valid JSON that isn't an object must be rejected cleanly."""
+        from openbadgeslib.keys import KeyRSA
+        k = KeyRSA()
+        k.read_public_key(rsa_pub_pem)
+        list_header = utils.encode(['not', 'a', 'dict'])
+        jws = list_header + b'.' + utils.encode(PAYLOAD) + b'.' + utils.to_base64(b'sig')
+        with pytest.raises(SignatureError):
+            verify_block(jws, key=k.get_pub_key())
+
+
+class TestExceptionHierarchy:
+    def test_all_jws_exceptions_are_libopenbadgesexception(self):
+        from openbadgeslib.errors import LibOpenBadgesException
+        for exc_cls in (MissingKey, MissingSigner, MissingVerifier, SignatureError, RouteMissingError):
+            assert issubclass(exc_cls, LibOpenBadgesException)
 
 
 # ── utils ──────────────────────────────────────────────────────────────────────

--- a/tests/test_verify_operation.py
+++ b/tests/test_verify_operation.py
@@ -33,6 +33,17 @@ class TestCheckJWSSignature:
         result = v.check_jws_signature(badge)
         assert result.status is BadgeStatus.SIGNATURE_ERROR
 
+    def test_malformed_jws_header_returns_signature_error(self, badge_for_verify_rsa):
+        from openbadgeslib._jws import utils as jws_utils
+        badge, identity = badge_for_verify_rsa
+        v = Verifier(identity=identity)
+
+        # Header is base64url-valid but not JSON at all.
+        badge.assertion.header = jws_utils.to_base64(b'not-json-at-all')
+
+        result = v.check_jws_signature(badge)
+        assert result.status is BadgeStatus.SIGNATURE_ERROR
+
 
 class TestCheckIdentity:
     def test_matching_identity_returns_true(self, badge_for_verify_rsa):


### PR DESCRIPTION
Wrap malformed/non-object JWS header parsing in verify_block() into
SignatureError instead of leaking a raw json.JSONDecodeError, and make
every openbadgeslib._jws exception class inherit from
errors.LibOpenBadgesException so none of them can escape verify()/sign()
as an unhandled exception.

Fixes #4
Verified: pytest (298 passed), flake8 clean, mypy success.
