### PR TITLE
fix(ob2): guard BadgeSigned.read_from_file against malformed bodies

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -11,6 +11,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     and every openbadgeslib._jws exception now inherits from
     LibOpenBadgesException so it can no longer escape verify()/sign() uncaught.
 
+  - fix: BadgeSigned.read_from_file() now raises AssertionFormatIncorrect
+    instead of a raw KeyError/AttributeError when the untrusted JWS body is
+    missing required fields (image, badge, uid, recipient, issuedOn).
+
 
 * v1.1.5 - 2026-06-30
 

--- a/openbadgeslib/ob2/badge.py
+++ b/openbadgeslib/ob2/badge.py
@@ -267,16 +267,20 @@ class BadgeSigned():
                 'Unable to verify OpenBadge: the verify key URL %s could not be '
                 'fetched (%s)' % (body['verify']['url'], exc)) from exc
 
-        badge = Badge(image_url=body['image'], verify_key_url=body['verify']['url'],
-                      json_url=body['badge'], key_type=key_type,
-                      pubkey_pem=pubkey_pem)
+        try:
+            badge = Badge(image_url=body['image'], verify_key_url=body['verify']['url'],
+                          json_url=body['badge'], key_type=key_type,
+                          pubkey_pem=pubkey_pem)
 
-        badge_sig = BadgeSigned(source=badge, serial_num=body['uid'],
-                                identity=body['recipient']['identity'].encode('utf-8'),
-                                evidence=evidence, expiration=expiration,
-                                salt=body['recipient']['salt'].encode('utf-8'),
-                                issue_date=body['issuedOn'],
-                                assertion=assertion)
+            badge_sig = BadgeSigned(source=badge, serial_num=body['uid'],
+                                    identity=body['recipient']['identity'].encode('utf-8'),
+                                    evidence=evidence, expiration=expiration,
+                                    salt=body['recipient']['salt'].encode('utf-8'),
+                                    issue_date=body['issuedOn'],
+                                    assertion=assertion)
+        except (KeyError, TypeError, AttributeError) as exc:
+            raise AssertionFormatIncorrect(
+                'OpenBadge assertion is missing or has a malformed field: %s' % exc) from exc
         return badge_sig
 
     def save_to_file(self, file_name: str) -> None:

--- a/tests/test_badge_io.py
+++ b/tests/test_badge_io.py
@@ -10,7 +10,7 @@ from openbadgeslib import baking
 from openbadgeslib.badge import (
     Assertion, extract_svg_assertion, extract_png_assertion, BadgeSigned,
 )
-from openbadgeslib.errors import BadgeImgFormatUnsupported
+from openbadgeslib.errors import BadgeImgFormatUnsupported, AssertionFormatIncorrect
 
 
 def _png_with_inserted_chunk(png_bytes, tag, data, index=1):
@@ -195,3 +195,29 @@ class TestBadgeSignedReadFromFile:
         with patch('openbadgeslib.ob2.badge.download_file', return_value=rsa_pub_pem):
             badge = BadgeSigned.read_from_file(path)
         assert isinstance(badge.get_serial_num(), str)
+
+    def _badge_with_tampered_body(self, tmp_path, signed_svg_rsa, svg_image, mutate):
+        from openbadgeslib._jws import utils as jws_utils
+
+        assertion = extract_svg_assertion(signed_svg_rsa.signed)
+        body = assertion.decode_body()
+        mutate(body)
+        new_body_b64 = jws_utils.encode(body)
+        tampered = assertion.header + b'.' + new_body_b64 + b'.' + assertion.signature
+
+        baked = baking.bake_svg(svg_image, tampered.decode('utf-8'))
+        return self._write_temp(tmp_path, baked, '.svg')
+
+    def test_missing_recipient_field_raises_clean_error(self, tmp_path, signed_svg_rsa, svg_image, rsa_pub_pem):
+        path = self._badge_with_tampered_body(
+            tmp_path, signed_svg_rsa, svg_image, lambda body: body.pop('recipient'))
+        with patch('openbadgeslib.ob2.badge.download_file', return_value=rsa_pub_pem):
+            with pytest.raises(AssertionFormatIncorrect):
+                BadgeSigned.read_from_file(path)
+
+    def test_missing_uid_field_raises_clean_error(self, tmp_path, signed_svg_rsa, svg_image, rsa_pub_pem):
+        path = self._badge_with_tampered_body(
+            tmp_path, signed_svg_rsa, svg_image, lambda body: body.pop('uid'))
+        with patch('openbadgeslib.ob2.badge.download_file', return_value=rsa_pub_pem):
+            with pytest.raises(AssertionFormatIncorrect):
+                BadgeSigned.read_from_file(path)


### PR DESCRIPTION
Wrap the untrusted-JWS-body field extraction in read_from_file() in a
try/except so a missing image/badge/uid/recipient/issuedOn field raises
AssertionFormatIncorrect instead of a raw KeyError/AttributeError that
would crash the verifier CLI uncaught.

Fixes #5
Verified: pytest (300 passed), flake8 clean, mypy success.
