### PR TITLE
fix(ob2): catch ValueError from download_file in get_badge_status

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -15,6 +15,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     instead of a raw KeyError/AttributeError when the untrusted JWS body is
     missing required fields (image, badge, uid, recipient, issuedOn).
 
+  - fix: Verifier.get_badge_status() now catches the ValueError download_file()
+    raises for a non-HTTPS revocation/issuer/badge URL and returns a clean
+    SIGNATURE_ERROR instead of letting it escape uncaught.
+
 
 * v1.1.5 - 2026-06-30
 

--- a/openbadgeslib/ob2/verifier.py
+++ b/openbadgeslib/ob2/verifier.py
@@ -89,6 +89,12 @@ class Verifier():
             return VerifyInfo(BadgeStatus.SIGNATURE_ERROR, e.reason)
         except URLError as e:
             return VerifyInfo(BadgeStatus.SIGNATURE_ERROR, e.reason)
+        except ValueError as e:
+            # download_file() (used by check_revocation for the badge JSON,
+            # issuer JSON, and revocation list URLs, all attacker-influenced)
+            # raises ValueError for a non-HTTPS URL; treat it the same as the
+            # network-error cases above instead of letting it escape uncaught.
+            return VerifyInfo(BadgeStatus.SIGNATURE_ERROR, str(e))
 
         # OK, all is correct.
         return VerifyInfo(BadgeStatus.VALID, 'OK')

--- a/tests/test_verify_operation.py
+++ b/tests/test_verify_operation.py
@@ -151,6 +151,15 @@ class TestGetBadgeStatus:
             result = v.get_badge_status(badge)
         assert result.status is BadgeStatus.EXPIRED
 
+    def test_non_https_revocation_url_returns_signature_error(self, badge_for_verify_rsa):
+        # download_file() raises a plain ValueError for a non-HTTPS URL; that
+        # must surface as a clean SIGNATURE_ERROR, not an unhandled exception.
+        badge, identity = badge_for_verify_rsa
+        v = Verifier(identity=identity)
+        with patch.object(v, 'check_revocation', side_effect=ValueError('insecure scheme')):
+            result = v.get_badge_status(badge)
+        assert result.status is BadgeStatus.SIGNATURE_ERROR
+
 
 class TestCheckRevocation:
     """Exercise the real check_revocation network/JSON chaining (mocked I/O)."""


### PR DESCRIPTION
check_revocation() calls download_file() on the badge JSON, issuer JSON,
and revocation list URLs, all derived from the untrusted assertion;
download_file() raises a plain ValueError for a non-HTTPS URL. Catch it
in get_badge_status() alongside HTTPError/URLError and return a clean
SIGNATURE_ERROR instead of letting it escape uncaught.

Fixes #9
Verified: pytest (301 passed), flake8 clean, mypy success.
