### PR TITLE
security(util): reject HTTPS-redirect-to-insecure-scheme downgrades

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -19,6 +19,11 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     raises for a non-HTTPS revocation/issuer/badge URL and returns a clean
     SIGNATURE_ERROR instead of letting it escape uncaught.
 
+  - SECURITY: download_file() now rejects an HTTP redirect to a non-HTTPS
+    target instead of transparently following it, closing a TLS scheme-
+    downgrade gap in the HTTPS-only enforcement used for the OB2 verify key,
+    issuer document, and revocation list.
+
 
 * v1.1.5 - 2026-06-30
 

--- a/openbadgeslib/util.py
+++ b/openbadgeslib/util.py
@@ -24,7 +24,7 @@
 __version__ = '1.1.5'
 
 import hashlib
-from typing import Optional, Union, overload
+from typing import Any, Optional, Union, overload
 from urllib import request
 from urllib.parse import urlparse
 
@@ -82,6 +82,29 @@ def hash_email(email: StrOrBytes, salt: StrOrBytes) -> bytes:
     return sha256_string(email + salt)
 
 
+class _HTTPSOnlyRedirectHandler(request.HTTPRedirectHandler):
+    """Reject any redirect whose target is not HTTPS.
+
+    Plain ``urlopen()`` follows redirects with the default HTTPRedirectHandler,
+    which never re-checks scheme: an https:// URL that 302s to http:// (or to
+    an attacker-chosen insecure origin) would be followed transparently,
+    defeating the HTTPS-only check below.
+    """
+
+    def __init__(self, allow_insecure: bool) -> None:
+        self._allow_insecure = allow_insecure
+
+    def redirect_request(self, req: Any, fp: Any, code: int, msg: str, headers: Any,
+                         newurl: str) -> Any:
+        new_scheme = urlparse(newurl).scheme
+        if new_scheme != 'https' and not self._allow_insecure:
+            raise ValueError(
+                'Refusing to follow redirect to %s over insecure %r scheme; HTTPS is '
+                'required (pass allow_insecure=True to override).'
+                % (newurl, new_scheme))
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
 def download_file(url: str, allow_insecure: bool = False) -> bytes:
     """Download a file over HTTPS using urllib's default TLS validation.
 
@@ -89,6 +112,7 @@ def download_file(url: str, allow_insecure: bool = False) -> bytes:
     OpenBadges 2.0 root of trust, so fetching it over an unauthenticated
     channel would let an active network attacker substitute their own key and
     forge badges. Pass ``allow_insecure=True`` to explicitly permit plain HTTP.
+    A redirect to a non-HTTPS target is rejected the same way.
     """
     u = urlparse(url)
 
@@ -100,7 +124,8 @@ def download_file(url: str, allow_insecure: bool = False) -> bytes:
                 % (url, u.scheme))
         print('Warning! %s does not use TLS.' % url)
 
-    with request.urlopen(url, timeout=30) as response:
+    opener = request.build_opener(_HTTPSOnlyRedirectHandler(allow_insecure))
+    with opener.open(url, timeout=30) as response:
         return response.read()
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -79,21 +79,31 @@ class TestHashEmail:
         assert isinstance(result, bytes)
 
 
-class TestDownloadFile:
-    def _mock_urlopen(self, content=b'file content'):
-        mock_resp = MagicMock()
-        mock_resp.__enter__ = lambda s: s
-        mock_resp.__exit__ = MagicMock(return_value=False)
-        mock_resp.read.return_value = content
-        return mock_resp
+def _mock_urlopen(content=b'file content'):
+    mock_resp = MagicMock()
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    mock_resp.read.return_value = content
+    return mock_resp
 
+
+def _mock_opener(content=b'file content', open_side_effect=None):
+    mock_opener = MagicMock()
+    if open_side_effect is not None:
+        mock_opener.open.side_effect = open_side_effect
+    else:
+        mock_opener.open.return_value = _mock_urlopen(content)
+    return mock_opener
+
+
+class TestDownloadFile:
     def test_returns_bytes_on_success(self):
-        with patch('openbadgeslib.util.request.urlopen', return_value=self._mock_urlopen()):
+        with patch('openbadgeslib.util.request.build_opener', return_value=_mock_opener()):
             result = download_file('https://example.com/file.pem')
         assert result == b'file content'
 
     def test_https_url_no_warning(self, capsys):
-        with patch('openbadgeslib.util.request.urlopen', return_value=self._mock_urlopen()):
+        with patch('openbadgeslib.util.request.build_opener', return_value=_mock_opener()):
             download_file('https://example.com/file.pem')
         out = capsys.readouterr().out
         assert 'Warning' not in out
@@ -104,23 +114,71 @@ class TestDownloadFile:
             download_file('http://example.com/file.pem')
 
     def test_http_url_allowed_with_flag_prints_warning(self, capsys):
-        with patch('openbadgeslib.util.request.urlopen', return_value=self._mock_urlopen()):
+        with patch('openbadgeslib.util.request.build_opener', return_value=_mock_opener()):
             download_file('http://example.com/file.pem', allow_insecure=True)
         out = capsys.readouterr().out
         assert 'Warning' in out
 
     def test_timeout_is_passed(self):
-        mock = self._mock_urlopen()
-        with patch('openbadgeslib.util.request.urlopen', return_value=mock) as m:
+        mock_opener = _mock_opener()
+        with patch('openbadgeslib.util.request.build_opener', return_value=mock_opener):
             download_file('https://example.com/file')
-        _, kwargs = m.call_args
+        _, kwargs = mock_opener.open.call_args
         assert kwargs.get('timeout') == 30
 
     def test_propagates_network_errors(self):
         from urllib.error import URLError
-        with patch('openbadgeslib.util.request.urlopen', side_effect=URLError('unreachable')):
+        mock_opener = _mock_opener(open_side_effect=URLError('unreachable'))
+        with patch('openbadgeslib.util.request.build_opener', return_value=mock_opener):
             with pytest.raises(URLError):
                 download_file('https://example.com/file')
+
+
+class TestHTTPSOnlyRedirectHandler:
+    """Regression coverage for the redirect scheme-downgrade fix."""
+
+    def _handler(self, allow_insecure=False):
+        from openbadgeslib.util import _HTTPSOnlyRedirectHandler
+        return _HTTPSOnlyRedirectHandler(allow_insecure)
+
+    def _get_request(self):
+        # The base HTTPRedirectHandler.redirect_request (called for an
+        # allowed scheme) requires a real GET/HEAD/POST method, not a
+        # MagicMock-generated one.
+        req = MagicMock()
+        req.get_method.return_value = 'GET'
+        req.get_full_url.return_value = 'https://example.com/original.pem'
+        req.unredirected_hdrs = {}
+        req.headers = {}
+        return req
+
+    def test_rejects_redirect_to_http(self):
+        with pytest.raises(ValueError):
+            self._handler().redirect_request(
+                self._get_request(), None, 302, 'Found', {}, 'http://evil.example.com/key.pem')
+
+    def test_rejects_redirect_to_non_https_scheme(self):
+        with pytest.raises(ValueError):
+            self._handler().redirect_request(
+                self._get_request(), None, 302, 'Found', {}, 'ftp://example.com/key.pem')
+
+    def test_allows_redirect_to_http_when_insecure_allowed(self):
+        req = self._handler(allow_insecure=True).redirect_request(
+            self._get_request(), None, 302, 'Found', {}, 'http://example.com/key.pem')
+        assert req is not None
+
+    def test_allows_redirect_to_https(self):
+        req = self._handler().redirect_request(
+            self._get_request(), None, 302, 'Found', {}, 'https://example.com/key.pem')
+        assert req is not None
+
+    def test_download_file_uses_https_only_redirect_handler(self):
+        from openbadgeslib.util import _HTTPSOnlyRedirectHandler
+        mock_opener = _mock_opener()
+        with patch('openbadgeslib.util.request.build_opener', return_value=mock_opener) as m:
+            download_file('https://example.com/file.pem')
+        (handler,), _ = m.call_args
+        assert isinstance(handler, _HTTPSOnlyRedirectHandler)
 
 
 class TestMisc:


### PR DESCRIPTION
download_file() checked the scheme of the caller-supplied URL but then
called the default urlopen(), whose HTTPRedirectHandler follows a
redirect to any scheme without re-checking it. An https:// verify-key,
issuer, or revocation URL could 302 to a plain http:// origin and the
attacker's bytes would be trusted as if fetched over HTTPS. Build a
custom opener with a redirect handler that rejects a non-HTTPS target
the same way the original URL is checked.

Fixes #13
Verified: pytest (306 passed), flake8 clean, mypy success.
