### PR TITLE
security(util): cap download_file response size at 5 MiB

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -24,6 +24,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     downgrade gap in the HTTPS-only enforcement used for the OB2 verify key,
     issuer document, and revocation list.
 
+  - SECURITY: download_file() now caps the response body at 5 MiB, bounding
+    memory use against an attacker-influenced URL serving an oversized
+    response.
+
 
 * v1.1.5 - 2026-06-30
 

--- a/openbadgeslib/util.py
+++ b/openbadgeslib/util.py
@@ -105,6 +105,12 @@ class _HTTPSOnlyRedirectHandler(request.HTTPRedirectHandler):
         return super().redirect_request(req, fp, code, msg, headers, newurl)
 
 
+#: Verify keys, issuer documents, and revocation lists are all small JSON/PEM
+#: payloads; cap reads well above any legitimate size to bound memory use
+#: against an attacker-influenced URL serving an oversized/streamed response.
+MAX_DOWNLOAD_SIZE = 5 * 1024 * 1024  # 5 MiB
+
+
 def download_file(url: str, allow_insecure: bool = False) -> bytes:
     """Download a file over HTTPS using urllib's default TLS validation.
 
@@ -112,7 +118,8 @@ def download_file(url: str, allow_insecure: bool = False) -> bytes:
     OpenBadges 2.0 root of trust, so fetching it over an unauthenticated
     channel would let an active network attacker substitute their own key and
     forge badges. Pass ``allow_insecure=True`` to explicitly permit plain HTTP.
-    A redirect to a non-HTTPS target is rejected the same way.
+    A redirect to a non-HTTPS target is rejected the same way. The response
+    body is bounded to MAX_DOWNLOAD_SIZE to limit memory use.
     """
     u = urlparse(url)
 
@@ -126,7 +133,19 @@ def download_file(url: str, allow_insecure: bool = False) -> bytes:
 
     opener = request.build_opener(_HTTPSOnlyRedirectHandler(allow_insecure))
     with opener.open(url, timeout=30) as response:
-        return response.read()
+        chunks = []
+        total = 0
+        while True:
+            chunk = response.read(65536)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > MAX_DOWNLOAD_SIZE:
+                raise ValueError(
+                    'Refusing to download %s: response exceeds the %d byte limit'
+                    % (url, MAX_DOWNLOAD_SIZE))
+            chunks.append(chunk)
+        return b''.join(chunks)
 
 
 def show_ecc_disclaimer() -> None:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -83,7 +83,8 @@ def _mock_urlopen(content=b'file content'):
     mock_resp = MagicMock()
     mock_resp.__enter__ = lambda s: s
     mock_resp.__exit__ = MagicMock(return_value=False)
-    mock_resp.read.return_value = content
+    # download_file() now reads in chunks until an empty read signals EOF.
+    mock_resp.read.side_effect = [content, b'']
     return mock_resp
 
 
@@ -132,6 +133,27 @@ class TestDownloadFile:
         with patch('openbadgeslib.util.request.build_opener', return_value=mock_opener):
             with pytest.raises(URLError):
                 download_file('https://example.com/file')
+
+    def test_oversized_response_raises(self):
+        from openbadgeslib.util import MAX_DOWNLOAD_SIZE
+        chunk = b'x' * 65536
+        n_chunks = MAX_DOWNLOAD_SIZE // len(chunk) + 2  # guaranteed to exceed the cap
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read.side_effect = [chunk] * n_chunks + [b'']
+        mock_opener = MagicMock()
+        mock_opener.open.return_value = mock_resp
+        with patch('openbadgeslib.util.request.build_opener', return_value=mock_opener):
+            with pytest.raises(ValueError):
+                download_file('https://example.com/huge-file')
+
+    def test_response_just_under_cap_succeeds(self):
+        from openbadgeslib.util import MAX_DOWNLOAD_SIZE
+        content = b'x' * (MAX_DOWNLOAD_SIZE - 1)
+        with patch('openbadgeslib.util.request.build_opener', return_value=_mock_opener(content)):
+            result = download_file('https://example.com/almost-too-big')
+        assert len(result) == MAX_DOWNLOAD_SIZE - 1
 
 
 class TestHTTPSOnlyRedirectHandler:


### PR DESCRIPTION
download_file() read the entire response body unconditionally; an
attacker-influenced URL (verify key, issuer document, revocation list)
serving an oversized or streamed response could exhaust memory. Read in
bounded chunks and raise ValueError once the cumulative size exceeds a
5 MiB cap, well above any legitimate PEM/JSON payload this function
fetches.

Fixes #14
Verified: pytest (308 passed), flake8 clean, mypy success.
