### PR TITLE
fix(confparser): validate [paths] base before use

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -28,6 +28,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     memory use against an attacker-influenced URL serving an oversized
     response.
 
+  - fix: ConfParser.read_conf() now raises a clean ValueError instead of a
+    raw KeyError/IndexError when config.ini is missing the [paths] section,
+    its 'base' key, or has an empty 'base' value.
+
 
 * v1.1.5 - 2026-06-30
 

--- a/openbadgeslib/confparser.py
+++ b/openbadgeslib/confparser.py
@@ -63,7 +63,17 @@ class ConfParser():
             # We should raise an UnicodeDecodeError, but the error message is too cryptic.#
             raise ValueError("The encoding of the configuration file and the default encoding of "
                              "the operating system mismatch") from None
-        if self.parser['paths']['base'][0] == '.':
+        try:
+            base = self.parser['paths']['base']
+        except KeyError:
+            raise ValueError(
+                "Configuration file %s is missing the [paths] section or its "
+                "'base' key" % self.config_file) from None
+        if not base:
+            raise ValueError(
+                "Configuration file %s has an empty [paths] 'base' value" % self.config_file)
+
+        if base[0] == '.':
             abs_path = os.path.dirname(self.config_file)
             full_path = os.path.abspath(abs_path)
             self.parser['paths']['base'] = full_path

--- a/tests/test_confparser.py
+++ b/tests/test_confparser.py
@@ -1,0 +1,35 @@
+"""Tests for openbadgeslib.confparser edge cases not covered elsewhere."""
+import pytest
+
+from openbadgeslib.confparser import ConfParser
+
+
+def _write(tmp_path, text):
+    p = tmp_path / 'config.ini'
+    p.write_text(text)
+    return str(p)
+
+
+class TestReadConfBaseValidation:
+    def test_missing_paths_section_raises_value_error(self, tmp_path):
+        path = _write(tmp_path, '[logs]\ngeneral = general.log\n')
+        with pytest.raises(ValueError):
+            ConfParser(path).read_conf()
+
+    def test_missing_base_key_raises_value_error(self, tmp_path):
+        path = _write(tmp_path, '[paths]\nbase_log = ./log\n')
+        with pytest.raises(ValueError):
+            ConfParser(path).read_conf()
+
+    def test_empty_base_value_raises_value_error(self, tmp_path):
+        path = _write(tmp_path, '[paths]\nbase = \n')
+        with pytest.raises(ValueError):
+            ConfParser(path).read_conf()
+
+    def test_relative_base_is_resolved_to_absolute(self, tmp_path):
+        path = _write(tmp_path, '[paths]\nbase = .\n')
+        conf = ConfParser(path).read_conf()
+        assert conf['paths']['base'] == str(tmp_path)
+
+    def test_nonexistent_file_returns_none(self, tmp_path):
+        assert ConfParser(str(tmp_path / 'missing.ini')).read_conf() is None


### PR DESCRIPTION
read_conf() indexed self.parser['paths']['base'][0] directly: a config
missing the [paths] section or its 'base' key raised a raw KeyError, and
an empty 'base' value raised IndexError. Every CLI entrypoint calls
read_config_or_exit() with no surrounding try/except for these, so a
malformed config crashed with an unhandled traceback. Validate base is
present and non-empty first, raising ValueError (matching this
function's existing error style) with a clear message.

Fixes #6
Verified: pytest (313 passed), flake8 clean, mypy success.
