### PR TITLE
fix(ob3): guard non-object vc claim and non-list vc.type

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -32,6 +32,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     raw KeyError/IndexError when config.ini is missing the [paths] section,
     its 'base' key, or has an empty 'base' value.
 
+  - fix: OB3Verifier.verify() now raises OB3VerificationError instead of a
+    raw AttributeError/TypeError when the JWT 'vc' claim is not an object, or
+    its 'type' field is not a string/list.
+
 
 * v1.1.5 - 2026-06-30
 

--- a/openbadgeslib/ob3/verifier.py
+++ b/openbadgeslib/ob3/verifier.py
@@ -156,9 +156,15 @@ class OB3Verifier:
             )
 
         vc = payload["vc"]
+        if not isinstance(vc, dict):
+            raise OB3VerificationError(
+                "JWT 'vc' claim must be an object, got %s" % type(vc).__name__)
+
         vc_types = vc.get("type", [])
         if isinstance(vc_types, str):
             vc_types = [vc_types]
+        elif not isinstance(vc_types, list):
+            vc_types = []
         if "OpenBadgeCredential" not in vc_types:
             raise OB3VerificationError(
                 "JWT 'vc' claim is not an OpenBadgeCredential (type=%r)" % (vc_types,)

--- a/tests/test_ob3_verifier.py
+++ b/tests/test_ob3_verifier.py
@@ -191,6 +191,22 @@ class TestOB3VerifierVerify:
         with pytest.raises(OB3VerificationError, match="ISO 8601"):
             ob3_rsa_verifier.verify(token)
 
+    # ── a non-object 'vc' claim, or a non-str/non-list 'vc.type', must not leak
+    #    a raw AttributeError/TypeError out of verify() ────────────────────────
+    @pytest.mark.parametrize('bad_vc', ['just-a-string', 12345, None, [], True])
+    def test_non_object_vc_claim_rejected(self, rsa_priv_pem, ob3_rsa_verifier, ob3_credential, bad_vc):
+        token = self._signed_with_vc(rsa_priv_pem, ob3_credential,
+                                     lambda p: p.__setitem__('vc', bad_vc))
+        with pytest.raises(OB3VerificationError, match="object"):
+            ob3_rsa_verifier.verify(token)
+
+    @pytest.mark.parametrize('bad_type', [None, 12345, {'not': 'a list'}])
+    def test_non_list_vc_type_rejected(self, rsa_priv_pem, ob3_rsa_verifier, ob3_credential, bad_type):
+        token = self._signed_with_vc(rsa_priv_pem, ob3_credential,
+                                     lambda p: p['vc'].__setitem__('type', bad_type))
+        with pytest.raises(OB3VerificationError, match="OpenBadgeCredential"):
+            ob3_rsa_verifier.verify(token)
+
     # ── array credentialSubject: the sub cross-check must normalise the list to
     #    its first element, not call .get() on the list (which raised a raw
     #    AttributeError that escaped verify()) ─────────────────────────────────


### PR DESCRIPTION
_build_credential() called vc.get("type", []) immediately after
payload["vc"], before OpenBadgeCredential.from_jwt_payload's own
guards run. A non-dict 'vc' (string, int, None, list, bool) raised a
raw AttributeError, and a dict 'vc' whose 'type' was not a str/list
raised a raw TypeError from the `in` check. Validate the vc shape up
front and raise OB3VerificationError instead.

Fixes #7
Verified: pytest (321 passed), flake8 clean, mypy success.
