### PR TITLE
fix(ob3): catch AttributeError in _parse_date for non-string claims

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -36,6 +36,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     raw AttributeError/TypeError when the JWT 'vc' claim is not an object, or
     its 'type' field is not a string/list.
 
+  - fix: _parse_date() now raises a clean ValueError instead of a raw
+    AttributeError when a vc date claim (validFrom/validUntil) is not a
+    string.
+
 
 * v1.1.5 - 2026-06-30
 

--- a/openbadgeslib/ob3/credential.py
+++ b/openbadgeslib/ob3/credential.py
@@ -237,7 +237,7 @@ def _parse_date(value: Any, where: str) -> datetime:
     """Parse an ISO 8601 date, raising a clear ValueError naming the field."""
     try:
         return _parse_iso(value)
-    except (ValueError, TypeError) as exc:
+    except (ValueError, TypeError, AttributeError) as exc:
         raise ValueError(
             "invalid ISO 8601 date in %s: %r" % (where, value)) from exc
 

--- a/tests/test_ob3_credential.py
+++ b/tests/test_ob3_credential.py
@@ -1,8 +1,10 @@
 """Tests for the OpenBadges 3.0 credential data model."""
 from datetime import datetime, timezone
 
+import pytest
+
 from openbadgeslib.ob3.credential import (
-    Achievement, Issuer, OpenBadgeCredential, OB3_CONTEXT, _iso, _parse_iso,
+    Achievement, Issuer, OpenBadgeCredential, OB3_CONTEXT, _iso, _parse_iso, _parse_date,
 )
 
 
@@ -243,3 +245,10 @@ class TestHelpers:
     def test_parse_iso_roundtrip(self):
         dt = datetime(2026, 7, 15, 8, 0, 0, tzinfo=timezone.utc)
         assert _parse_iso(_iso(dt)) == dt
+
+    @pytest.mark.parametrize('bad_value', [12345, None, [], {}, True])
+    def test_parse_date_non_string_raises_clean_value_error(self, bad_value):
+        # A non-string date claim must not leak a raw AttributeError from
+        # _parse_iso's str.replace() call.
+        with pytest.raises(ValueError):
+            _parse_date(bad_value, 'vc.validFrom')

--- a/tests/test_ob3_verifier.py
+++ b/tests/test_ob3_verifier.py
@@ -191,6 +191,14 @@ class TestOB3VerifierVerify:
         with pytest.raises(OB3VerificationError, match="ISO 8601"):
             ob3_rsa_verifier.verify(token)
 
+    def test_non_string_date_rejected(self, rsa_priv_pem, ob3_rsa_verifier, ob3_credential):
+        # A non-string validFrom must not leak a raw AttributeError out of
+        # verify() (_parse_iso calls str.replace() on it directly).
+        token = self._signed_with_vc(rsa_priv_pem, ob3_credential,
+                                     lambda p: p['vc'].__setitem__('validFrom', 12345))
+        with pytest.raises(OB3VerificationError, match="ISO 8601"):
+            ob3_rsa_verifier.verify(token)
+
     # ── a non-object 'vc' claim, or a non-str/non-list 'vc.type', must not leak
     #    a raw AttributeError/TypeError out of verify() ────────────────────────
     @pytest.mark.parametrize('bad_vc', ['just-a-string', 12345, None, [], True])


### PR DESCRIPTION
_parse_date() only caught (ValueError, TypeError) from _parse_iso(),
but a non-string date claim (e.g. an int) makes _parse_iso's
s.replace() call raise AttributeError, which escaped as a raw
exception instead of the intended clean ValueError. Add AttributeError
to the catch.

Fixes #8
Verified: pytest (327 passed), flake8 clean, mypy success.
