### PR TITLE
fix(ob2): guard check_expiration against a non-numeric expires claim

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -40,6 +40,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     AttributeError when a vc date claim (validFrom/validUntil) is not a
     string.
 
+  - fix: Verifier.check_expiration() now raises AssertionFormatIncorrect
+    instead of a raw TypeError when the untrusted 'expires' claim is not a
+    numeric timestamp.
+
 
 * v1.1.5 - 2026-06-30
 

--- a/openbadgeslib/ob2/verifier.py
+++ b/openbadgeslib/ob2/verifier.py
@@ -164,7 +164,13 @@ class Verifier():
 
         # A badge is expired when its expiration timestamp is in the past
         # relative to *now* — not relative to its own issue date.
-        if badge.expiration < time():
+        try:
+            expired = badge.expiration < time()
+        except TypeError as exc:
+            raise AssertionFormatIncorrect(
+                "Badge 'expires' field is not a valid timestamp: %r" % (badge.expiration,)) from exc
+
+        if expired:
             return "%s" % strftime("%a, %d %b %Y %H:%M:%S +0000",
                                    gmtime(badge.expiration))
         else:

--- a/tests/test_verify_operation.py
+++ b/tests/test_verify_operation.py
@@ -94,6 +94,16 @@ class TestCheckExpiration:
         assert result is not None
         assert isinstance(result, str)
 
+    def test_non_numeric_expiration_raises_clean_error(self, badge_for_verify_rsa):
+        from openbadgeslib.errors import AssertionFormatIncorrect
+        badge, identity = badge_for_verify_rsa
+        v = Verifier(identity=identity)
+        # An untrusted 'expires' claim of the wrong type must not raise a raw
+        # TypeError from the `<` comparison.
+        badge.expiration = 'not-a-timestamp'
+        with pytest.raises(AssertionFormatIncorrect):
+            v.check_expiration(badge)
+
 
 class TestGetBadgeStatus:
     def test_valid_badge_returns_valid(self, badge_for_verify_rsa):


### PR DESCRIPTION
badge.expiration is populated straight from the untrusted JWS body's
'expires' field with no type validation. check_expiration() did
`badge.expiration < time()` unguarded, so a non-numeric value raised a
raw TypeError instead of a clean library exception. Wrap the comparison
and raise AssertionFormatIncorrect, matching the pattern already used
elsewhere in this file for malformed assertion data.

Fixes #10
Verified: pytest (328 passed), flake8 clean, mypy success.
