### PR TITLE
fix(ob2): wrap extract_png_assertion exceptions like its SVG counterpart

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -44,6 +44,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     instead of a raw TypeError when the untrusted 'expires' claim is not a
     numeric timestamp.
 
+  - fix: extract_png_assertion() now wraps baking.extract_png() the same way
+    its SVG counterpart does, raising ErrorParsingFile instead of letting a
+    raw exception escape on a malformed/garbage PNG.
+
 
 * v1.1.5 - 2026-06-30
 

--- a/openbadgeslib/ob2/badge.py
+++ b/openbadgeslib/ob2/badge.py
@@ -335,7 +335,10 @@ def extract_svg_assertion(file_data: bytes) -> Assertion:
 
 
 def extract_png_assertion(file_data: bytes) -> Assertion:
-    token = baking.extract_png(file_data)
+    try:
+        token = baking.extract_png(file_data)
+    except Exception as err:
+        raise ErrorParsingFile('Error parsing PNG file: %s' % err) from err
     if token is None:
         raise AssertionFormatIncorrect('No OpenBadges assertion found in PNG file')
     return Assertion.decode(token.encode('utf-8'))

--- a/tests/test_badge_io.py
+++ b/tests/test_badge_io.py
@@ -115,6 +115,14 @@ class TestExtractPNGAssertion:
         with pytest.raises(AssertionFormatIncorrect):
             extract_png_assertion(png_with_comment)
 
+    def test_garbage_bytes_raise_clean_error(self):
+        # Not PNG at all: baking.extract_png's underlying chunk reader raises
+        # its own exception; that must not leak out raw (mirrors the SVG
+        # counterpart's try/except around baking.extract_svg).
+        from openbadgeslib.errors import ErrorParsingFile
+        with pytest.raises(ErrorParsingFile):
+            extract_png_assertion(b'this is not a png file at all')
+
 
 class TestBakingPNGAssertionDetection:
     def test_has_png_detects_baked_assertion(self, png_image):


### PR DESCRIPTION
extract_svg_assertion() wraps baking.extract_svg() in try/except and
re-raises as ErrorParsingFile, but extract_png_assertion() called
baking.extract_png() unguarded, letting the PNG chunk reader's raw
exceptions (e.g. on garbage/malformed PNG bytes) escape uncaught.
Apply the same wrapping.

Fixes #11
Verified: pytest (329 passed), flake8 clean, mypy success.
