### PR TITLE
fix(ob2): raise clean errors on corrupt key material in Badge.__init__

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -48,6 +48,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     its SVG counterpart does, raising ErrorParsingFile instead of letting a
     raw exception escape on a malformed/garbage PNG.
 
+  - fix: Badge.__init__ now raises PrivateKeyReadError/PublicKeyReadError
+    instead of a raw ValueError/binascii.Error when a configured private or
+    public key file is corrupt, truncated, or mismatched with its key type.
+
 
 * v1.1.5 - 2026-06-30
 

--- a/openbadgeslib/ob2/badge.py
+++ b/openbadgeslib/ob2/badge.py
@@ -30,7 +30,8 @@ from ecdsa import SigningKey, VerifyingKey
 
 from ..keys import KeyType, detect_key_type
 from ..errors import (BadgeImgFormatUnsupported, AssertionFormatIncorrect,
-                      ErrorParsingFile, UnknownKeyType)
+                      ErrorParsingFile, UnknownKeyType, PrivateKeyReadError,
+                      PublicKeyReadError)
 from .._jws import utils as jws_utils
 from ..util import hash_email, download_file
 from .. import baking
@@ -117,14 +118,26 @@ class Badge():
         # Initialize an Key Object
         if self.key_type is KeyType.RSA:
             if self.pubkey_pem:
-                self.pub_key = RSA.import_key(self.pubkey_pem)
+                try:
+                    self.pub_key = RSA.import_key(self.pubkey_pem)
+                except Exception as exc:
+                    raise PublicKeyReadError('Unable to read RSA public key: %s' % exc) from exc
             if self.privkey_pem:
-                self.priv_key = RSA.import_key(self.privkey_pem)
+                try:
+                    self.priv_key = RSA.import_key(self.privkey_pem)
+                except Exception as exc:
+                    raise PrivateKeyReadError('Unable to read RSA private key: %s' % exc) from exc
         elif self.key_type is KeyType.ECC:
             if self.pubkey_pem:
-                self.pub_key = VerifyingKey.from_pem(self.pubkey_pem)
+                try:
+                    self.pub_key = VerifyingKey.from_pem(self.pubkey_pem)
+                except Exception as exc:
+                    raise PublicKeyReadError('Unable to read ECC public key: %s' % exc) from exc
             if self.privkey_pem:
-                self.priv_key = SigningKey.from_pem(self.privkey_pem)
+                try:
+                    self.priv_key = SigningKey.from_pem(self.privkey_pem)
+                except Exception as exc:
+                    raise PrivateKeyReadError('Unable to read ECC private key: %s' % exc) from exc
         elif self.key_type is not None:
             # key_type=None is a valid "no key material yet" state; any other
             # value is an unsupported key type and must fail loudly.

--- a/tests/test_badge_io.py
+++ b/tests/test_badge_io.py
@@ -8,9 +8,12 @@ from png import Reader, signature as png_signature
 
 from openbadgeslib import baking
 from openbadgeslib.badge import (
-    Assertion, extract_svg_assertion, extract_png_assertion, BadgeSigned,
+    Assertion, extract_svg_assertion, extract_png_assertion, BadgeSigned, Badge,
 )
-from openbadgeslib.errors import BadgeImgFormatUnsupported, AssertionFormatIncorrect
+from openbadgeslib.keys import KeyType
+from openbadgeslib.errors import (
+    BadgeImgFormatUnsupported, AssertionFormatIncorrect, PrivateKeyReadError,
+)
 
 
 def _png_with_inserted_chunk(png_bytes, tag, data, index=1):
@@ -229,3 +232,15 @@ class TestBadgeSignedReadFromFile:
         with patch('openbadgeslib.ob2.badge.download_file', return_value=rsa_pub_pem):
             with pytest.raises(AssertionFormatIncorrect):
                 BadgeSigned.read_from_file(path)
+
+
+class TestBadgeInitCorruptKey:
+    """A corrupt/mismatched private key must not leak a raw ValueError/binascii.Error."""
+
+    def test_rsa_corrupt_private_key_raises_clean_error(self, rsa_pub_pem):
+        with pytest.raises(PrivateKeyReadError):
+            Badge(key_type=KeyType.RSA, privkey_pem=b'not a real PEM key', pubkey_pem=rsa_pub_pem)
+
+    def test_ecc_corrupt_private_key_raises_clean_error(self, ecc_pub_pem):
+        with pytest.raises(PrivateKeyReadError):
+            Badge(key_type=KeyType.ECC, privkey_pem=b'not a real PEM key', pubkey_pem=ecc_pub_pem)


### PR DESCRIPTION
Badge.__init__ called RSA.import_key/VerifyingKey.from_pem/
SigningKey.from_pem unguarded, so a corrupt, truncated, or key-type-
mismatched private/public key file raised a raw ValueError or
binascii.Error instead of a LibOpenBadgesException subclass, crashing
the signer/keygen CLIs uncaught. Wrap each call and re-raise as the
existing PrivateKeyReadError/PublicKeyReadError from errors.py.

Fixes #12
Verified: pytest (331 passed), flake8 clean, mypy success.
