### PR TITLE
docs(wiki): add the required DIRECTORY argument to openbadges-init

### DIFF
--- a/wiki/Quick-Start.md
+++ b/wiki/Quick-Start.md
@@ -5,7 +5,7 @@ This walkthrough takes you from an empty directory to a signed, verified Open Ba
 Create the config directory and a starter `config.ini`:
 
 ```sh
-openbadges-init
+openbadges-init ./config
 ```
 
 The example config ships with two badge sections (`[badge_1]`, `[badge_2]`), an `[issuer]` section, and `[paths]` pointing keys at `${base}/keys`. Edit the issuer details and at least one `[badge_*]` section before continuing. The default key type is RSA (`key_type = RSA`; `ECC` is the alternative).


### PR DESCRIPTION
Quick-Start.md showed `openbadges-init` with no argument, but the
script requires exactly one positional DIRECTORY argument and exits
immediately with a usage message otherwise. Every other page
(CLI-Reference, Installation, Authors-License-and-FAQ, README) already
documents it correctly as `openbadges-init ./config`.

Fixes #17
Verified: pytest tests/test_docs.py (8 passed), full suite (331 passed).
