### PR TITLE
test(cli): lock openbadges-init directory permissions at 0700

### DIFF
--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -16,6 +16,21 @@ def test_init_creates_directory_layout(tmp_path):
         assert (target / sub).is_dir()
 
 
+def test_init_creates_directories_with_restrictive_permissions(tmp_path):
+    # The keys/ subdirectory will hold private key material; openbadges_init
+    # applies a 0o077 umask around the mkdir calls so every created directory
+    # (not just keys/) ends up owner-only (0700), not world/group readable.
+    import os
+    import stat
+    from openbadgeslib import openbadges_init
+    target = tmp_path / 'config'
+    with patch.object(sys, 'argv', ['openbadges-init', str(target)]):
+        openbadges_init.main()
+    for path in (target, target / 'keys', target / 'images', target / 'log'):
+        mode = stat.S_IMODE(os.stat(path).st_mode)
+        assert mode == 0o700, '%s has mode %o, expected 0700' % (path, mode)
+
+
 # ── openbadges-keygenerator honours key_type from the badge profile ─────────────
 
 def _write_keygen_config(tmp_path, key_type):


### PR DESCRIPTION
openbadges_init.main() applies a 0o077 umask around its mkdir calls so
the created directory tree is owner-only, but nothing asserted that.
Add a regression test checking the mode of the top-level directory and
each subdirectory (keys/, images/, log/), so a future refactor cannot
silently weaken this without a test failing.

Fixes #19
Verified: pytest (332 passed), flake8 clean, mypy success.
