### PR TITLE
fix(mail): catch ValueError from smtplib CRLF guard in BadgeMail.send

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -52,6 +52,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     instead of a raw ValueError/binascii.Error when a configured private or
     public key file is corrupt, truncated, or mismatched with its key type.
 
+  - fix: BadgeMail.send() now catches the ValueError smtplib raises as its
+    CRLF header-injection guard for a malformed from/recipient address,
+    reporting a clean mail-failure message instead of crashing.
+
 
 * v1.1.5 - 2026-06-30
 

--- a/openbadgeslib/mail.py
+++ b/openbadgeslib/mail.py
@@ -89,10 +89,12 @@ class BadgeMail():
 
             smtp.sendmail(self.mail_from, badge.get_identity(), msg.as_string())
             smtp.quit()
-        except (SMTPException, OSError) as err:
+        except (SMTPException, OSError, ValueError) as err:
             # Connection refused, DNS failure, TLS mismatch, SMTP protocol
-            # errors — the badge is already signed and saved, so report the
-            # mail failure instead of crashing with a traceback.
+            # errors, or a CR/LF in mail_from/recipient (smtplib itself
+            # raises a bare ValueError as its header-injection guard) — the
+            # badge is already signed and saved, so report the mail failure
+            # instead of crashing with a traceback.
             print('[!] Error sending mail to: %s. %s' % (badge.get_identity(), err))
 
     def get_mail_content(self, file: str) -> Tuple[Optional[str], Optional[str]]:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -297,6 +297,26 @@ def test_badgemail_send_success_invokes_smtp(svg_rsa_badge):
     smtp.quit.assert_called_once()
 
 
+def test_badgemail_send_handles_crlf_injection_value_error(svg_rsa_badge, capsys):
+    # smtplib itself raises a bare ValueError as its CRLF header-injection
+    # guard for a malformed from/to address; that must not crash send().
+    from openbadgeslib.mail import BadgeMail
+    from unittest.mock import MagicMock
+
+    signed = _signed_for_mail(svg_rsa_badge, 'svg')
+    mail = BadgeMail(smtp_server='localhost', smtp_port=25, use_ssl=False,
+                     mail_from='from@example.com')
+    mail.set_subject('subject')
+    mail.set_body('body')
+
+    smtp = MagicMock()
+    smtp.sendmail.side_effect = ValueError('An address is only allowed to have <>')
+    with patch('openbadgeslib.mail.SMTP', return_value=smtp):
+        mail.send(signed)  # must not raise
+
+    assert 'Error sending mail' in capsys.readouterr().out
+
+
 def test_badgemail_auth_requires_ssl():
     import pytest
     from openbadgeslib.mail import BadgeMail


### PR DESCRIPTION
smtplib.SMTP.sendmail raises a bare ValueError as its own header-
injection guard when mail_from or the recipient identity contains
CR/LF. BadgeMail.send() only caught (SMTPException, OSError) around
the send, so that ValueError escaped uncaught even though the badge is
already signed and saved. Add ValueError to the catch, matching the
existing "report, don't crash" pattern for other mail failures.

Fixes #15
Verified: pytest (333 passed), flake8 clean, mypy success.
