### PR TITLE
fix(confparser): validate ExtendedInterpolation references eagerly

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -56,6 +56,11 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     CRLF header-injection guard for a malformed from/recipient address,
     reporting a clean mail-failure message instead of crashing.
 
+  - fix: ConfParser.read_conf() now eagerly resolves every ${...}
+    ExtendedInterpolation reference at load time, raising a clean ValueError
+    for a malformed reference instead of letting a raw configparser
+    exception escape lazily, deep inside a CLI tool.
+
 
 * v1.1.5 - 2026-06-30
 

--- a/openbadgeslib/confparser.py
+++ b/openbadgeslib/confparser.py
@@ -21,7 +21,7 @@
         License along with this library.
 """
 
-from configparser import ConfigParser, ExtendedInterpolation
+from configparser import ConfigParser, ExtendedInterpolation, Error as ConfigParserError
 from typing import Optional
 import os
 import sys
@@ -77,6 +77,19 @@ class ConfParser():
             abs_path = os.path.dirname(self.config_file)
             full_path = os.path.abspath(abs_path)
             self.parser['paths']['base'] = full_path
+
+        # ExtendedInterpolation resolves ${...} references lazily, only when a
+        # value is actually read — a bad reference anywhere in the file would
+        # otherwise surface as a raw configparser exception deep inside a CLI
+        # tool the first time it happens to touch that key. Resolve every
+        # value now so a malformed config fails cleanly, here, at load time.
+        try:
+            for section in self.parser.sections():
+                dict(self.parser.items(section))
+        except ConfigParserError as exc:
+            raise ValueError(
+                "Configuration file %s has an invalid value: %s" % (self.config_file, exc)) from exc
+
         return self.parser
 
 

--- a/tests/test_confparser.py
+++ b/tests/test_confparser.py
@@ -33,3 +33,21 @@ class TestReadConfBaseValidation:
 
     def test_nonexistent_file_returns_none(self, tmp_path):
         assert ConfParser(str(tmp_path / 'missing.ini')).read_conf() is None
+
+    def test_bad_interpolation_reference_raises_clean_value_error(self, tmp_path):
+        # ExtendedInterpolation resolves ${...} lazily; a bad reference in a
+        # section other than [paths] must surface here, at load time, as a
+        # clean ValueError — not as a raw configparser.Error deep inside a
+        # CLI tool the first time that key happens to be read.
+        path = _write(tmp_path, '[paths]\nbase = .\n\n[badge_1]\nimage = ${missing}/x.svg\n')
+        with pytest.raises(ValueError):
+            ConfParser(path).read_conf()
+
+    def test_valid_interpolation_reference_resolves(self, tmp_path):
+        path = _write(
+            tmp_path,
+            '[paths]\nbase = .\nbase_image = ${base}/images\n\n'
+            '[badge_1]\nimage = ${paths:base_image}/x.svg\n',
+        )
+        conf = ConfParser(path).read_conf()
+        assert conf['badge_1']['image'] == '%s/images/x.svg' % conf['paths']['base']


### PR DESCRIPTION
ExtendedInterpolation resolves ${...} references lazily, only when a
value is read. A malformed reference anywhere outside [paths]/base
previously surfaced as a raw configparser exception deep inside a CLI
tool the first time it happened to touch that key, with no wrapping
anywhere in the codebase. Resolve every section's values right after
read_conf() validates 'base', so a bad reference fails cleanly, here,
as a ValueError.

Fixes #16
Verified: pytest (335 passed), flake8 clean, mypy success.
