### PR TITLE
security(ob3): re-validate vc.validUntil/validFrom independently

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -61,6 +61,12 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     for a malformed reference instead of letting a raw configparser
     exception escape lazily, deep inside a CLI tool.
 
+  - SECURITY: OB3Verifier.verify() now independently re-validates
+    vc.validUntil/validFrom against wall-clock time, instead of relying only
+    on the JWT 'exp' claim, which can be decoupled from the vc-level dates
+    that downstream consumers actually read. An expired or not-yet-valid
+    credential is now rejected regardless of the JWT claim.
+
 
 * v1.1.5 - 2026-06-30
 

--- a/openbadgeslib/ob3/verifier.py
+++ b/openbadgeslib/ob3/verifier.py
@@ -20,6 +20,7 @@
         License along with this library.
 """
 
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 import jwt
@@ -103,6 +104,19 @@ class OB3Verifier:
         """
         payload = self._decode_payload(token)
         credential = self._build_credential(payload)
+
+        # The JWT 'exp'/'iat' claims (checked above by PyJWT) are attacker-
+        # supplied and can be decoupled from vc.validUntil/validFrom, which is
+        # what downstream consumers actually read. Re-validate the vc-level
+        # dates against wall-clock time independently, mirroring OB2Verifier's
+        # check_expiration().
+        now = datetime.now(timezone.utc)
+        if credential.expiration_date is not None and credential.expiration_date < now:
+            raise OB3VerificationError(
+                "Credential has expired (validUntil %s)" % credential.expiration_date.isoformat())
+        if credential.issuance_date is not None and credential.issuance_date > now:
+            raise OB3VerificationError(
+                "Credential is not yet valid (validFrom %s)" % credential.issuance_date.isoformat())
 
         if expected_recipient is not None:
             expected = normalize_recipient_id(expected_recipient)

--- a/tests/test_ob3_verifier.py
+++ b/tests/test_ob3_verifier.py
@@ -95,6 +95,28 @@ class TestOB3VerifierVerify:
         with pytest.raises(OB3VerificationError, match="expired"):
             ob3_rsa_verifier.verify(token)
 
+    def test_expired_vc_validuntil_rejected_independent_of_exp_claim(
+        self, rsa_priv_pem, ob3_rsa_verifier, ob3_credential
+    ):
+        # The base credential has no expiration_date, so to_jwt_payload()
+        # never sets the top-level 'exp' claim: PyJWT's own expiry check
+        # cannot fire. vc.validUntil is the untrusted claim downstream
+        # consumers actually read, and it must be re-checked independently.
+        token = self._signed_with_vc(
+            rsa_priv_pem, ob3_credential,
+            lambda p: p['vc'].__setitem__('validUntil', '2000-01-01T00:00:00Z'))
+        with pytest.raises(OB3VerificationError, match="expired"):
+            ob3_rsa_verifier.verify(token)
+
+    def test_future_vc_validfrom_rejected_as_not_yet_valid(
+        self, rsa_priv_pem, ob3_rsa_verifier, ob3_credential
+    ):
+        token = self._signed_with_vc(
+            rsa_priv_pem, ob3_credential,
+            lambda p: p['vc'].__setitem__('validFrom', '2099-01-01T00:00:00Z'))
+        with pytest.raises(OB3VerificationError, match="not yet valid"):
+            ob3_rsa_verifier.verify(token)
+
     def test_not_a_jwt_vc_raises(self, ob3_rsa_verifier, signed_svg_rsa):
         # OB 2.0 assertion embedded in SVG — extract the raw JWS string and
         # pass it to the OB 3.0 verifier, which should reject it.


### PR DESCRIPTION
OB3Verifier.verify() only relied on PyJWT's check of the top-level
JWT 'exp' claim. That claim can be decoupled from vc.validUntil/
validFrom (the dates downstream consumers actually read from the
credential), so a token with an expired or not-yet-valid vc but a
missing/future 'exp' claim verified successfully. Re-check the
reconstructed credential's dates against wall-clock time, mirroring
OB2Verifier.check_expiration()'s independent re-validation.

Fixes #40
Verified: pytest (339 passed), flake8 clean, mypy success.
