### PR TITLE
fix(jws): wrap malformed signature segment decode into SignatureError

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -67,6 +67,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     that downstream consumers actually read. An expired or not-yet-valid
     credential is now rejected regardless of the JWT claim.
 
+  - fix: verify_block() now wraps a malformed (invalid-length) base64url JWS
+    signature segment into SignatureError instead of leaking a raw
+    binascii.Error.
+
 
 * v1.1.5 - 2026-06-30
 

--- a/openbadgeslib/_jws/__init__.py
+++ b/openbadgeslib/_jws/__init__.py
@@ -95,7 +95,10 @@ def verify_block(msg: Union[str, bytes], key: Optional[Any] = None) -> bool:
             % alg_name)
 
     signing_input = head_b64 + b'.' + payload_b64
-    raw_sig = utils.from_base64(sig_b64)
+    try:
+        raw_sig = utils.from_base64(sig_b64)
+    except (ValueError, TypeError) as exc:
+        raise SignatureError("Malformed JWS signature") from exc
 
     algo = _algo_for(alg_name)
     try:

--- a/tests/test_jws.py
+++ b/tests/test_jws.py
@@ -146,6 +146,15 @@ class TestVerifyBlockEdgeCases:
         with pytest.raises(SignatureError):
             verify_block(jws, key=k.get_pub_key())
 
+    def test_malformed_signature_segment_raises_signature_error(self, rsa_pub_pem):
+        """An invalid-length base64url signature segment must not leak binascii.Error."""
+        from openbadgeslib.keys import KeyRSA
+        k = KeyRSA()
+        k.read_public_key(rsa_pub_pem)
+        jws = utils.encode({'alg': 'RS256'}) + b'.' + utils.encode(PAYLOAD) + b'.A'
+        with pytest.raises(SignatureError):
+            verify_block(jws, key=k.get_pub_key())
+
 
 class TestExceptionHierarchy:
     def test_all_jws_exceptions_are_libopenbadgesexception(self):


### PR DESCRIPTION
verify_block() wraps the header decode into SignatureError, but the
signature segment (utils.from_base64(sig_b64)) had no exception
handling at all. A JWS with an invalid-length base64url signature
segment raised a raw binascii.Error, escaping uncaught through
ob2/verifier.py's narrow except clause and crashing the verifier CLI
on attacker-supplied badge content.

Fixes #39
Verified: pytest (340 passed), flake8 clean, mypy success.
