### PR TITLE
fix(ob2): catch JWSException in check_jws_signature, not just SignatureError

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -71,6 +71,11 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     signature segment into SignatureError instead of leaking a raw
     binascii.Error.
 
+  - fix: Verifier.check_jws_signature() now catches the JWSException base
+    class instead of only SignatureError, so a JWS header missing 'alg' or
+    a completely missing verification key resolves to a clean
+    SIGNATURE_ERROR instead of an uncaught exception.
+
 
 * v1.1.5 - 2026-06-30
 

--- a/openbadgeslib/ob2/verifier.py
+++ b/openbadgeslib/ob2/verifier.py
@@ -26,7 +26,7 @@ from typing import Any, Optional
 from .badge import BadgeStatus
 from ..util import hash_email, download_file, show_ecc_disclaimer
 from ..keys import KeyType, detect_key_type
-from .._jws.exceptions import SignatureError as JWS_SignatureError
+from .._jws.exceptions import JWSException
 from .._jws import verify_block as jws_verify_block
 from .._jws import utils as jws_utils
 from ..errors import AssertionFormatIncorrect, NotIdentityInAssertion
@@ -108,7 +108,10 @@ class Verifier():
         try:
             jws_verify_block(badge.assertion.get_assertion(), verify_key)
             return VerifyInfo(BadgeStatus.VALID, 'OK')
-        except JWS_SignatureError as err:
+        except JWSException as err:
+            # Any JWS-layer failure — bad signature, malformed/missing 'alg',
+            # missing key, unsupported algorithm — is a clean, untrusted-input
+            # driven signature-verification failure, not a library bug.
             return VerifyInfo(BadgeStatus.SIGNATURE_ERROR, str(err))
 
     def check_revocation(self, badge: Any) -> Optional[str]:

--- a/tests/test_verify_operation.py
+++ b/tests/test_verify_operation.py
@@ -44,6 +44,32 @@ class TestCheckJWSSignature:
         result = v.check_jws_signature(badge)
         assert result.status is BadgeStatus.SIGNATURE_ERROR
 
+    def test_header_missing_alg_returns_signature_error(self, badge_for_verify_rsa):
+        # verify_block() raises MissingVerifier (a JWSException sibling of
+        # SignatureError) for a header missing 'alg'; check_jws_signature()
+        # must catch that too, not just SignatureError itself.
+        from openbadgeslib._jws import utils as jws_utils
+        badge, identity = badge_for_verify_rsa
+        v = Verifier(identity=identity)
+
+        badge.assertion.header = jws_utils.encode({'typ': 'JWS'})  # no 'alg'
+
+        result = v.check_jws_signature(badge)
+        assert result.status is BadgeStatus.SIGNATURE_ERROR
+
+    def test_missing_verification_key_returns_signature_error(self, badge_for_verify_rsa):
+        # verify_block() raises MissingKey when no key is available at all
+        # (no trusted key and no badge-embedded key); that must also resolve
+        # to a clean SIGNATURE_ERROR, not an uncaught exception.
+        # badge.source is a shared fixture object (see conftest.py), so patch
+        # its pub_key temporarily rather than mutating it in place.
+        badge, identity = badge_for_verify_rsa
+        v = Verifier(identity=identity)
+
+        with patch.object(badge.source, 'pub_key', None):
+            result = v.check_jws_signature(badge)
+        assert result.status is BadgeStatus.SIGNATURE_ERROR
+
 
 class TestCheckIdentity:
     def test_matching_identity_returns_true(self, badge_for_verify_rsa):


### PR DESCRIPTION
verify_block() can raise MissingVerifier, MissingKey, or RouteMissingError
for an untrusted JWS header missing 'alg', a missing key, or an
unsupported algorithm — siblings of SignatureError, all JWSException
subclasses since the exception-hierarchy fix. check_jws_signature()
only caught SignatureError itself, so those siblings still escaped
uncaught through get_badge_status() and the CLI's exception handling.
Catch the JWSException base class instead.

Fixes #38
Verified: pytest (342 passed), flake8 clean, mypy success.
