### PR TITLE
fix(ob2): guard read_from_file's verify-url lookup against malformed bodies

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -76,6 +76,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     a completely missing verification key resolves to a clean
     SIGNATURE_ERROR instead of an uncaught exception.
 
+  - fix: BadgeSigned.read_from_file() now raises ErrorParsingFile instead of
+    a raw KeyError/TypeError when the untrusted JWS body is missing 'verify'
+    or has a non-object 'verify' field.
+
 
 * v1.1.5 - 2026-06-30
 

--- a/openbadgeslib/ob2/badge.py
+++ b/openbadgeslib/ob2/badge.py
@@ -272,16 +272,24 @@ class BadgeSigned():
         except KeyError:
             expiration = None
 
+        # Read the verify URL once, before the try block, so a missing or
+        # malformed 'verify' object cannot raise a fresh, unwrapped
+        # KeyError/TypeError when the except clause below re-references it.
+        verify_dict = body.get('verify')
+        verify_url = verify_dict.get('url') if isinstance(verify_dict, dict) else None
+        if not verify_url:
+            raise ErrorParsingFile("OpenBadge assertion body is missing 'verify.url'")
+
         try:
-            pubkey_pem = download_file(body['verify']['url'])
+            pubkey_pem = download_file(verify_url)
             key_type = detect_key_type(pubkey_pem)
         except Exception as exc:
             raise ErrorParsingFile(
                 'Unable to verify OpenBadge: the verify key URL %s could not be '
-                'fetched (%s)' % (body['verify']['url'], exc)) from exc
+                'fetched (%s)' % (verify_url, exc)) from exc
 
         try:
-            badge = Badge(image_url=body['image'], verify_key_url=body['verify']['url'],
+            badge = Badge(image_url=body['image'], verify_key_url=verify_url,
                           json_url=body['badge'], key_type=key_type,
                           pubkey_pem=pubkey_pem)
 

--- a/tests/test_badge_io.py
+++ b/tests/test_badge_io.py
@@ -12,7 +12,7 @@ from openbadgeslib.badge import (
 )
 from openbadgeslib.keys import KeyType
 from openbadgeslib.errors import (
-    BadgeImgFormatUnsupported, AssertionFormatIncorrect, PrivateKeyReadError,
+    BadgeImgFormatUnsupported, AssertionFormatIncorrect, PrivateKeyReadError, ErrorParsingFile,
 )
 
 
@@ -231,6 +231,23 @@ class TestBadgeSignedReadFromFile:
             tmp_path, signed_svg_rsa, svg_image, lambda body: body.pop('uid'))
         with patch('openbadgeslib.ob2.badge.download_file', return_value=rsa_pub_pem):
             with pytest.raises(AssertionFormatIncorrect):
+                BadgeSigned.read_from_file(path)
+
+    def test_missing_verify_field_raises_clean_error(self, tmp_path, signed_svg_rsa, svg_image, rsa_pub_pem):
+        # The except clause used to re-reference body['verify']['url'] while
+        # formatting its own error message, raising a fresh unwrapped
+        # KeyError instead of ErrorParsingFile.
+        path = self._badge_with_tampered_body(
+            tmp_path, signed_svg_rsa, svg_image, lambda body: body.pop('verify'))
+        with patch('openbadgeslib.ob2.badge.download_file', return_value=rsa_pub_pem):
+            with pytest.raises(ErrorParsingFile):
+                BadgeSigned.read_from_file(path)
+
+    def test_non_dict_verify_field_raises_clean_error(self, tmp_path, signed_svg_rsa, svg_image, rsa_pub_pem):
+        path = self._badge_with_tampered_body(
+            tmp_path, signed_svg_rsa, svg_image, lambda body: body.__setitem__('verify', 'not-a-dict'))
+        with patch('openbadgeslib.ob2.badge.download_file', return_value=rsa_pub_pem):
+            with pytest.raises(ErrorParsingFile):
                 BadgeSigned.read_from_file(path)
 
 


### PR DESCRIPTION
The except clause around download_file(body['verify']['url']) re-
referenced that same expression while formatting its own error message.
If the original failure was caused by 'verify' being missing or not a
dict, the message-formatting line raised a brand-new, unwrapped
KeyError/TypeError instead of the intended ErrorParsingFile. Read the
verify URL once, up front, with a type check, and reuse it everywhere
else in this method.

Fixes #37
Verified: pytest (344 passed), flake8 clean, mypy success.
