### PR TITLE
fix(ob2): validate check_revocation's fetched JSON is an object

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -80,6 +80,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     a raw KeyError/TypeError when the untrusted JWS body is missing 'verify'
     or has a non-object 'verify' field.
 
+  - fix: Verifier.check_revocation() now raises AssertionFormatIncorrect
+    instead of a raw AttributeError/TypeError when the fetched badge,
+    issuer, or revocation-list JSON is valid JSON but not an object.
+
 
 * v1.1.5 - 2026-06-30
 

--- a/openbadgeslib/ob2/verifier.py
+++ b/openbadgeslib/ob2/verifier.py
@@ -127,6 +127,8 @@ class Verifier():
             badge_obj = jws_utils.from_json(badge_json)
         except Exception:
             raise AssertionFormatIncorrect("Badge JSON format incorrect at %s" % json_url)
+        if not isinstance(badge_obj, dict):
+            raise AssertionFormatIncorrect("Badge JSON at %s is not a JSON object" % json_url)
 
         issuer_url = badge_obj.get('issuer')
         if not issuer_url:
@@ -139,6 +141,8 @@ class Verifier():
             issuer = jws_utils.from_json(issuer_json)
         except Exception:
             raise AssertionFormatIncorrect("Issuer JSON format incorrect at %s" % issuer_url)
+        if not isinstance(issuer, dict):
+            raise AssertionFormatIncorrect("Issuer JSON at %s is not a JSON object" % issuer_url)
 
         # revocationList is optional in OpenBadges 2.0; its absence means the
         # issuer publishes no revocations, so the badge is simply not revoked.
@@ -154,6 +158,9 @@ class Verifier():
         except Exception:
             raise AssertionFormatIncorrect(
                 "Revocation list format incorrect at %s" % revocation_url)
+        if not isinstance(revocation, dict):
+            raise AssertionFormatIncorrect(
+                "Revocation list at %s is not a JSON object" % revocation_url)
 
         if revocation:
             for badge_id in revocation:

--- a/tests/test_verify_operation.py
+++ b/tests/test_verify_operation.py
@@ -270,6 +270,51 @@ class TestCheckRevocation:
             with pytest.raises(AssertionFormatIncorrect):
                 v.check_revocation(badge)
 
+    def test_non_object_badge_json_raises_clean_error(self, badge_for_verify_rsa):
+        # Valid JSON that isn't an object (e.g. an array) must not raise a
+        # raw AttributeError from badge_obj.get('issuer').
+        from openbadgeslib.errors import AssertionFormatIncorrect
+        badge, identity = badge_for_verify_rsa
+        v = Verifier(identity=identity)
+        with patch('openbadgeslib.ob2.verifier.download_file', return_value=b'[1, 2, 3]'):
+            with pytest.raises(AssertionFormatIncorrect):
+                v.check_revocation(badge)
+
+    def test_non_object_issuer_json_raises_clean_error(self, badge_for_verify_rsa):
+        import json as _json
+        from openbadgeslib.errors import AssertionFormatIncorrect
+        badge, identity = badge_for_verify_rsa
+        v = Verifier(identity=identity)
+        badge_json = {'issuer': 'https://example.com/issuer.json'}
+
+        def fake_download(url, *a, **k):
+            if url == badge.source.json_url:
+                return _json.dumps(badge_json).encode()
+            return b'"just-a-string"'   # issuer body is valid JSON, not an object
+
+        with patch('openbadgeslib.ob2.verifier.download_file', side_effect=fake_download):
+            with pytest.raises(AssertionFormatIncorrect):
+                v.check_revocation(badge)
+
+    def test_non_object_revocation_json_raises_clean_error(self, badge_for_verify_rsa):
+        import json as _json
+        from openbadgeslib.errors import AssertionFormatIncorrect
+        badge, identity = badge_for_verify_rsa
+        v = Verifier(identity=identity)
+        badge_json = {'issuer': 'https://example.com/issuer.json'}
+        issuer_json = {'revocationList': 'https://example.com/revoked.json'}
+
+        def fake_download(url, *a, **k):
+            if url == badge.source.json_url:
+                return _json.dumps(badge_json).encode()
+            if url == badge_json['issuer']:
+                return _json.dumps(issuer_json).encode()
+            return b'[1, 2, 3]'   # revocation list is valid JSON, not an object
+
+        with patch('openbadgeslib.ob2.verifier.download_file', side_effect=fake_download):
+            with pytest.raises(AssertionFormatIncorrect):
+                v.check_revocation(badge)
+
 
 class TestEmbeddedKeyFallback:
     """The verify_key=None path trusts the key embedded in the badge itself —


### PR DESCRIPTION
check_revocation() downloads three attacker-influenced documents
(badge, issuer, revocation list) and immediately dict-indexes each
decoded value without checking it is actually a JSON object. Valid
JSON that decodes to a list, string, number, or null raised a raw
AttributeError/TypeError instead of AssertionFormatIncorrect. Add an
isinstance(dict) check after each jws_utils.from_json() call,
mirroring the pattern already used for OB3's untrusted vc claim.

Fixes #41
Verified: pytest (347 passed), flake8 clean, mypy success.
