### PR TITLE
fix(signer): wrap baking exceptions into ErrorSigningFile on sign

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -84,6 +84,11 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     instead of a raw AttributeError/TypeError when the fetched badge,
     issuer, or revocation-list JSON is valid JSON but not an object.
 
+  - fix: Signer (OB2) and OB3Signer now wrap baking.has_svg/has_png/bake_svg/
+    bake_png into ErrorSigningFile instead of letting a raw
+    ExpatError/AttributeError/png.FormatError escape when the carrier image
+    is malformed.
+
 
 * v1.1.5 - 2026-06-30
 

--- a/openbadgeslib/ob2/signer.py
+++ b/openbadgeslib/ob2/signer.py
@@ -142,20 +142,32 @@ class Signer():
         """ Append the assertion to a SVG File """
         assertion = badge.get_assertion()
         assert assertion is not None  # set by generate_assertion before baking
-        badge.signed = baking.bake_svg(
-            badge.source.image, assertion,
-            comment=' Signed with OpenBadgesLib %s ' % __version__)
+        try:
+            badge.signed = baking.bake_svg(
+                badge.source.image, assertion,
+                comment=' Signed with OpenBadgesLib %s ' % __version__)
+        except Exception as exc:
+            raise ErrorSigningFile('Unable to bake SVG assertion: %s' % exc) from exc
 
     def append_png_assertion(self, badge: BadgeSigned) -> None:
         """ Append the assertion to a PNG file """
         assertion = badge.get_assertion()
         assert assertion is not None  # set by generate_assertion before baking
-        badge.signed = baking.bake_png(
-            badge.source.image, assertion,
-            text_comment='Comment Signed with OpenBadgesLib %s' % __version__)
+        try:
+            badge.signed = baking.bake_png(
+                badge.source.image, assertion,
+                text_comment='Comment Signed with OpenBadgesLib %s' % __version__)
+        except Exception as exc:
+            raise ErrorSigningFile('Unable to bake PNG assertion: %s' % exc) from exc
 
     def has_svg_assertion(self, badge: Any) -> bool:
-        return baking.has_svg(badge.image)
+        try:
+            return baking.has_svg(badge.image)
+        except Exception as exc:
+            raise ErrorSigningFile('Unable to parse SVG image: %s' % exc) from exc
 
     def has_png_assertion(self, badge: Any) -> bool:
-        return baking.has_png(badge.image)
+        try:
+            return baking.has_png(badge.image)
+        except Exception as exc:
+            raise ErrorSigningFile('Unable to parse PNG image: %s' % exc) from exc

--- a/openbadgeslib/ob3/signer.py
+++ b/openbadgeslib/ob3/signer.py
@@ -27,6 +27,7 @@ import jwt
 from .credential import OpenBadgeCredential, _SUPPORTED_ALGORITHMS
 from ..util import __version__
 from ..keys import key_to_pem
+from ..errors import ErrorSigningFile
 from .. import baking
 
 
@@ -67,9 +68,12 @@ class OB3Signer:
         viewers can extract the token regardless of version.
         """
         token = self.sign(credential)
-        return baking.bake_svg(
-            svg_bytes, token,
-            comment=' Signed with OpenBadgesLib %s (OB 3.0 JWT-VC) ' % __version__)
+        try:
+            return baking.bake_svg(
+                svg_bytes, token,
+                comment=' Signed with OpenBadgesLib %s (OB 3.0 JWT-VC) ' % __version__)
+        except Exception as exc:
+            raise ErrorSigningFile('Unable to bake SVG assertion: %s' % exc) from exc
 
     def sign_into_png(self, credential: OpenBadgeCredential, png_bytes: bytes) -> bytes:
         """Embed a signed credential into a PNG badge image.
@@ -78,4 +82,7 @@ class OB3Signer:
         matching the OB 2.0 baking format.
         """
         token = self.sign(credential)
-        return baking.bake_png(png_bytes, token)
+        try:
+            return baking.bake_png(png_bytes, token)
+        except Exception as exc:
+            raise ErrorSigningFile('Unable to bake PNG assertion: %s' % exc) from exc

--- a/tests/test_ob3_signer.py
+++ b/tests/test_ob3_signer.py
@@ -114,6 +114,11 @@ class TestSignIntoSVG:
         assert doc.getElementsByTagName('openbadges:assertion').length == 1
         doc.unlink()
 
+    def test_malformed_svg_raises_error_signing_file(self, ob3_rsa_signer, ob3_credential):
+        from openbadgeslib.errors import ErrorSigningFile
+        with pytest.raises(ErrorSigningFile):
+            ob3_rsa_signer.sign_into_svg(ob3_credential, b'not even xml <<<')
+
 
 # ── sign_into_png() ────────────────────────────────────────────────────────────
 
@@ -146,3 +151,8 @@ class TestSignIntoPNG:
             for tag, data in Reader(bytes=result).chunks()
         )
         assert found
+
+    def test_malformed_png_raises_error_signing_file(self, ob3_rsa_signer, ob3_credential):
+        from openbadgeslib.errors import ErrorSigningFile
+        with pytest.raises(ErrorSigningFile):
+            ob3_rsa_signer.sign_into_png(ob3_credential, b'not a png at all')

--- a/tests/test_signer_operation.py
+++ b/tests/test_signer_operation.py
@@ -361,3 +361,35 @@ class TestSignerOutputFilenameValidation:
     def test_safe_filename_component_rejects_path_values(self, value):
         with pytest.raises(ValueError):
             _safe_filename_component(value, 'field')
+
+
+class TestSignMalformedImage:
+    """Malformed carrier images must raise ErrorSigningFile, not a raw
+    baking-library exception (mirrors ob2/badge.py's extract_*_assertion)."""
+
+    def test_has_svg_assertion_on_non_xml_raises_error_signing_file(self):
+        badge = Badge(image_type=BadgeImgType.SVG, image=b'not even xml <<<', key_type=KeyType.RSA)
+        s = Signer(identity='a@b.com', badge_type=BadgeType.SIGNED)
+        with pytest.raises(ErrorSigningFile):
+            s.has_assertion(badge)
+
+    def test_has_png_assertion_on_non_png_raises_error_signing_file(self):
+        badge = Badge(image_type=BadgeImgType.PNG, image=b'not a png at all', key_type=KeyType.RSA)
+        s = Signer(identity='a@b.com', badge_type=BadgeType.SIGNED)
+        with pytest.raises(ErrorSigningFile):
+            s.has_assertion(badge)
+
+    def test_sign_svg_without_svg_root_raises_error_signing_file(self, rsa_priv_pem, rsa_pub_pem):
+        # Well-formed XML but no <svg> root: has_svg_assertion succeeds (no
+        # baked assertion found), but bake_svg itself fails since there is
+        # no <svg> element to attach the assertion to.
+        badge = Badge(
+            image_type=BadgeImgType.SVG,
+            image=b'<?xml version="1.0"?><root><child/></root>',
+            key_type=KeyType.RSA,
+            privkey_pem=rsa_priv_pem,
+            pubkey_pem=rsa_pub_pem,
+        )
+        s = Signer(identity='a@b.com', badge_type=BadgeType.SIGNED, deterministic=True)
+        with pytest.raises(ErrorSigningFile):
+            s.sign_badge(badge)


### PR DESCRIPTION
Signer.has_svg_assertion/has_png_assertion/append_svg_assertion/
append_png_assertion (OB2) and OB3Signer.sign_into_svg/sign_into_png
called baking.has_svg/has_png/bake_svg/bake_png with no exception
handling. A malformed carrier image (non-XML, XML without an <svg>
root, or a non-PNG byte string) raised a raw
ExpatError/AttributeError/png.FormatError instead of a
LibOpenBadgesException subclass, crashing the signer CLI uncaught.
Wrap each call, mirroring the pattern already used in
ob2/badge.py's extract_svg_assertion/extract_png_assertion.

Fixes #42
Verified: pytest (352 passed), flake8 clean, mypy success.
