### PR TITLE
fix(cli): restore umask in a try/finally in init and publish

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -89,6 +89,11 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     ExpatError/AttributeError/png.FormatError escape when the carrier image
     is malformed.
 
+  - fix: openbadges-init and openbadges-publish now restore the process
+    umask in a try/finally, so a failure partway through directory/file
+    creation can no longer leave the umask permanently changed for the rest
+    of the process.
+
 
 * v1.1.5 - 2026-06-30
 

--- a/openbadgeslib/openbadges_init.py
+++ b/openbadgeslib/openbadges_init.py
@@ -45,10 +45,12 @@ def main() -> None:
         raise FileExistsError(directory)
 
     umask = os.umask(0o077)  # rwx------
-    os.mkdir(directory)
-    for subdir in ['keys', 'images', 'log']:
-        os.mkdir(os.path.join(directory, subdir))
-    os.umask(umask)
+    try:
+        os.mkdir(directory)
+        for subdir in ['keys', 'images', 'log']:
+            os.mkdir(os.path.join(directory, subdir))
+    finally:
+        os.umask(umask)
 
     source = os.path.join(os.path.dirname(__file__), 'config.ini.example')
     destination = os.path.join(directory, 'config.ini')

--- a/openbadgeslib/openbadges_publish.py
+++ b/openbadgeslib/openbadges_publish.py
@@ -70,35 +70,36 @@ def main() -> None:
             raise FileExistsError(args.output)
 
         umask = os.umask(0o077)  # rwx------
-        os.mkdir(args.output)
+        try:
+            os.mkdir(args.output)
 
-        issuer = create_issuer_json(conf)
-        issuer_file = os.path.join(args.output, 'organization.json')
-        with open(issuer_file, "w", encoding='ascii') as f:
-            f.write(issuer)
+            issuer = create_issuer_json(conf)
+            issuer_file = os.path.join(args.output, 'organization.json')
+            with open(issuer_file, "w", encoding='ascii') as f:
+                f.write(issuer)
 
-        revocation = create_revocation_json(conf)
-        revocation_file = os.path.join(args.output, 'revoked.json')
-        with open(revocation_file, "w", encoding='ascii') as f:
-            f.write(revocation)
+            revocation = create_revocation_json(conf)
+            revocation_file = os.path.join(args.output, 'revoked.json')
+            with open(revocation_file, "w", encoding='ascii') as f:
+                f.write(revocation)
 
-        for badge_name in conf.sections():
-            if not badge_name.startswith('badge_'):
-                continue
+            for badge_name in conf.sections():
+                if not badge_name.startswith('badge_'):
+                    continue
 
-            badge_path = os.path.join(args.output, badge_name)
-            badge_file = os.path.join(badge_path, 'badge.json')
+                badge_path = os.path.join(args.output, badge_name)
+                badge_file = os.path.join(badge_path, 'badge.json')
 
-            os.mkdir(badge_path)
-            with open(badge_file, "w", encoding='ascii') as f:
-                f.write(create_badge_json(conf, badge_name))
+                os.mkdir(badge_path)
+                with open(badge_file, "w", encoding='ascii') as f:
+                    f.write(create_badge_json(conf, badge_name))
 
-            """ Copy the verify key for this badge """
-            source = conf[badge_name]['public_key']
-            destination = os.path.join(badge_path, 'verify.pem')
-            shutil.copyfile(source, destination)
-
-        os.umask(umask)
+                """ Copy the verify key for this badge """
+                source = conf[badge_name]['public_key']
+                destination = os.path.join(badge_path, 'verify.pem')
+                shutil.copyfile(source, destination)
+        finally:
+            os.umask(umask)
 
         print('Please configure your Web server to publish the folder %s as %s' %
               (args.output, conf['issuer']['publish_url']))

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -31,6 +31,35 @@ def test_init_creates_directories_with_restrictive_permissions(tmp_path):
         assert mode == 0o700, '%s has mode %o, expected 0700' % (path, mode)
 
 
+def test_init_restores_umask_when_a_subdirectory_mkdir_fails(tmp_path):
+    # If any mkdir after os.umask(0o077) raises, the original umask must
+    # still be restored — otherwise it stays at 0o077 for the rest of the
+    # process (test_cli_smoke.py runs entrypoints in-process).
+    import os
+    import pytest
+    from openbadgeslib import openbadges_init
+
+    original = os.umask(0)
+    os.umask(original)  # just peeking; restore immediately
+
+    target = tmp_path / 'config'
+    real_mkdir = os.mkdir
+
+    def flaky_mkdir(path, *a, **k):
+        if str(path).endswith('images'):
+            raise OSError('simulated mkdir failure')
+        return real_mkdir(path, *a, **k)
+
+    with patch.object(sys, 'argv', ['openbadges-init', str(target)]):
+        with patch('openbadgeslib.openbadges_init.os.mkdir', side_effect=flaky_mkdir):
+            with pytest.raises(OSError):
+                openbadges_init.main()
+
+    after = os.umask(0)
+    os.umask(after)
+    assert after == original
+
+
 # ── openbadges-keygenerator honours key_type from the badge profile ─────────────
 
 def _write_keygen_config(tmp_path, key_type):
@@ -226,6 +255,36 @@ def test_publish_ob2_creates_full_tree(tmp_path):
     for name in ('badge_test_1', 'badge_test_2', 'badge_test_3', 'badge_test_4'):
         assert (out / name / 'badge.json').is_file()
         assert (out / name / 'verify.pem').is_file()
+
+
+def test_publish_restores_umask_when_a_badge_mkdir_fails(tmp_path):
+    # If any step after os.umask(0o077) raises (a badge section's mkdir, a
+    # missing public_key file, ...), the original umask must still be
+    # restored rather than staying at 0o077 for the rest of the process.
+    import os
+    import pytest
+    from openbadgeslib import openbadges_publish
+
+    original = os.umask(0)
+    os.umask(original)  # just peeking; restore immediately
+
+    out = tmp_path / 'published'
+    argv = ['openbadges-publish', '-c', './config1.ini', '-o', str(out)]
+    real_mkdir = os.mkdir
+
+    def flaky_mkdir(path, *a, **k):
+        if 'badge_test_1' in str(path):
+            raise OSError('simulated mkdir failure')
+        return real_mkdir(path, *a, **k)
+
+    with patch.object(sys, 'argv', argv):
+        with patch('openbadgeslib.openbadges_publish.os.mkdir', side_effect=flaky_mkdir):
+            with pytest.raises(OSError):
+                openbadges_publish.main()
+
+    after = os.umask(0)
+    os.umask(after)
+    assert after == original
 
 
 # ── Badge.urls_has_problems ─────────────────────────────────────────────────────


### PR DESCRIPTION
Both openbadges-init and openbadges-publish call os.umask(0o077) then
perform several operations (mkdir, file writes, shutil.copyfile) that
can raise before restoring the original umask. If any of them failed,
the restore line never ran and the process umask stayed at 0o077 for
the remainder of the process — relevant since tests, and any
programmatic embedding, call these main() functions in-process. Wrap
the guarded body in try/finally in both files.

Fixes #47
Verified: pytest (354 passed), flake8 clean, mypy success.
