### PR TITLE
fix(util): case-insensitive mailto matching for OB3 recipient binding

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -94,6 +94,12 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     creation can no longer leave the umask permanently changed for the rest
     of the process.
 
+  - fix: normalize_recipient_id() no longer double-prefixes an
+    already-mailto: URI whose scheme is spelled in a different case, and
+    OB3Verifier.verify()'s recipient binding now compares mailto: URIs
+    case-insensitively (DIDs remain compared exactly), so a legitimate
+    recipient is no longer wrongly rejected for a casing difference.
+
 
 * v1.1.5 - 2026-06-30
 

--- a/openbadgeslib/ob3/verifier.py
+++ b/openbadgeslib/ob3/verifier.py
@@ -29,7 +29,7 @@ import jwt.exceptions
 from .credential import OpenBadgeCredential
 from ..errors import ErrorParsingFile, UnknownKeyType, LibOpenBadgesException
 from ..keys import KeyType, detect_key_type, key_to_pem
-from ..util import normalize_recipient_id
+from ..util import normalize_recipient_id, recipient_ids_match
 from .. import baking
 
 # Signature algorithms accepted per key family. The signer only ever emits the
@@ -120,7 +120,7 @@ class OB3Verifier:
 
         if expected_recipient is not None:
             expected = normalize_recipient_id(expected_recipient)
-            if credential.recipient_id != expected:
+            if not recipient_ids_match(credential.recipient_id, expected):
                 raise OB3VerificationError(
                     "Recipient mismatch: credential is for %s, expected %s"
                     % (credential.recipient_id, expected)

--- a/openbadgeslib/util.py
+++ b/openbadgeslib/util.py
@@ -69,9 +69,26 @@ def normalize_recipient_id(value: Optional[str]) -> Optional[str]:
     """
     if value is None:
         return None
-    if not value.startswith('mailto:') and '@' in value:
+    if not value.lower().startswith('mailto:') and '@' in value:
         return 'mailto:' + value
     return value
+
+
+def recipient_ids_match(a: Optional[str], b: Optional[str]) -> bool:
+    """Compare two credentialSubject.id values for recipient binding.
+
+    A ``mailto:`` URI is compared case-insensitively (RFC 6068 treats the
+    scheme as case-insensitive, and email addresses are conventionally
+    treated the same way), so a recipient who signed with one casing and
+    verifies with another is not wrongly rejected. Anything else (in
+    particular a DID) is compared exactly, since DID method-specific
+    identifiers can be case-sensitive.
+    """
+    if a is None or b is None:
+        return a == b
+    if a.lower().startswith('mailto:') and b.lower().startswith('mailto:'):
+        return a.lower() == b.lower()
+    return a == b
 
 
 def hash_email(email: StrOrBytes, salt: StrOrBytes) -> bytes:

--- a/tests/test_ob3_verifier.py
+++ b/tests/test_ob3_verifier.py
@@ -289,6 +289,28 @@ class TestOB3VerifierRecipientBinding:
         restored = ob3_rsa_verifier.verify(token, expected_recipient=did)
         assert restored.recipient_id == did
 
+    def test_mixed_case_mailto_recipient_still_matches(
+        self, ob3_rsa_signer, ob3_rsa_verifier, ob3_credential
+    ):
+        # The email was baked in with one casing at sign time; verifying with
+        # a differently-cased spelling of the same address must still match.
+        from dataclasses import replace
+        cred = replace(ob3_credential, recipient_id='mailto:John@Example.com')
+        token = ob3_rsa_signer.sign(cred)
+        restored = ob3_rsa_verifier.verify(token, expected_recipient='john@example.com')
+        assert restored.recipient_id == 'mailto:John@Example.com'
+
+    def test_case_sensitive_did_mismatch_still_raises(
+        self, ob3_rsa_signer, ob3_rsa_verifier, ob3_credential
+    ):
+        # Unlike mailto: URIs, DIDs are compared exactly — a differently-cased
+        # DID must still be rejected as a mismatch.
+        from dataclasses import replace
+        cred = replace(ob3_credential, recipient_id='did:example:ABC123')
+        token = ob3_rsa_signer.sign(cred)
+        with pytest.raises(OB3VerificationError, match="mismatch"):
+            ob3_rsa_verifier.verify(token, expected_recipient='did:example:abc123')
+
     def test_non_openbadge_credential_type_rejected(self, rsa_priv_pem, ob3_rsa_verifier, ob3_credential):
         import jwt as _jwt
         payload = ob3_credential.to_jwt_payload()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -7,7 +7,7 @@ import pytest
 from openbadgeslib.util import (
     sha1_string, sha256_string, md5_string,
     hash_email, download_file, show_ecc_disclaimer,
-    normalize_recipient_id,
+    normalize_recipient_id, recipient_ids_match,
     __version__,
 )
 
@@ -226,3 +226,31 @@ class TestNormalizeRecipientId:
 
     def test_none_passthrough(self):
         assert normalize_recipient_id(None) is None
+
+    def test_uppercase_mailto_scheme_not_double_prefixed(self):
+        # The scheme check must be case-insensitive (RFC 6068): an
+        # already-prefixed URI in a different case must not get a second
+        # 'mailto:' prepended.
+        assert normalize_recipient_id('MAILTO:a@b.com') == 'MAILTO:a@b.com'
+
+
+class TestRecipientIdsMatch:
+    def test_mailto_case_insensitive_match(self):
+        assert recipient_ids_match('mailto:John@Example.com', 'mailto:john@example.com')
+
+    def test_mailto_mixed_scheme_case_match(self):
+        assert recipient_ids_match('mailto:a@b.com', 'MAILTO:A@B.COM')
+
+    def test_did_is_case_sensitive(self):
+        assert not recipient_ids_match('did:example:ABC', 'did:example:abc')
+
+    def test_did_exact_match(self):
+        assert recipient_ids_match('did:example:abc', 'did:example:abc')
+
+    def test_none_only_matches_none(self):
+        assert recipient_ids_match(None, None)
+        assert not recipient_ids_match(None, 'mailto:a@b.com')
+        assert not recipient_ids_match('mailto:a@b.com', None)
+
+    def test_different_recipients_do_not_match(self):
+        assert not recipient_ids_match('mailto:a@b.com', 'mailto:c@d.com')


### PR DESCRIPTION
normalize_recipient_id()'s scheme check was case-sensitive, so an
already-prefixed URI spelled 'MAILTO:...' got double-prefixed into
'mailto:MAILTO:...'. Separately, OB3Verifier.verify() compared
credential.recipient_id to the expected recipient with an exact string
match, so a recipient who signed with one casing of their email and
verified with another got a false 'Recipient mismatch'. Fix the scheme
check and add recipient_ids_match(), which compares mailto: URIs
case-insensitively while still comparing DIDs exactly (DID
method-specific identifiers can be case-sensitive).

Fixes #43
Verified: pytest (363 passed), flake8 clean, mypy success.
