### PR TITLE
fix(confparser): catch configparser.Error from parser.read()

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -100,6 +100,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     case-insensitively (DIDs remain compared exactly), so a legitimate
     recipient is no longer wrongly rejected for a casing difference.
 
+  - fix: ConfParser.read_conf() now raises a clean ValueError instead of a
+    raw configparser exception for malformed INI syntax (duplicate
+    section/option, a value line with no section header).
+
 
 * v1.1.5 - 2026-06-30
 

--- a/openbadgeslib/confparser.py
+++ b/openbadgeslib/confparser.py
@@ -63,6 +63,12 @@ class ConfParser():
             # We should raise an UnicodeDecodeError, but the error message is too cryptic.#
             raise ValueError("The encoding of the configuration file and the default encoding of "
                              "the operating system mismatch") from None
+        except ConfigParserError as exc:
+            # Malformed INI syntax (duplicate section/option, a value line
+            # with no section header before it, ...) raises directly from
+            # read(), before any interpolation is even attempted.
+            raise ValueError(
+                "Configuration file %s has invalid INI syntax: %s" % (self.config_file, exc)) from exc
         try:
             base = self.parser['paths']['base']
         except KeyError:

--- a/tests/test_confparser.py
+++ b/tests/test_confparser.py
@@ -51,3 +51,20 @@ class TestReadConfBaseValidation:
         )
         conf = ConfParser(path).read_conf()
         assert conf['badge_1']['image'] == '%s/images/x.svg' % conf['paths']['base']
+
+    def test_duplicate_section_raises_value_error(self, tmp_path):
+        # DuplicateSectionError raises directly from parser.read(), before
+        # [paths]/base is ever touched.
+        path = _write(tmp_path, '[paths]\nbase = .\n\n[paths]\nbase = .\n')
+        with pytest.raises(ValueError):
+            ConfParser(path).read_conf()
+
+    def test_duplicate_option_raises_value_error(self, tmp_path):
+        path = _write(tmp_path, '[paths]\nbase = .\nbase = ./other\n')
+        with pytest.raises(ValueError):
+            ConfParser(path).read_conf()
+
+    def test_missing_section_header_raises_value_error(self, tmp_path):
+        path = _write(tmp_path, 'base = .\n\n[paths]\nbase = .\n')
+        with pytest.raises(ValueError):
+            ConfParser(path).read_conf()


### PR DESCRIPTION
Malformed INI syntax (a duplicate section, a duplicate option, or a
value line with no section header before it) raises a configparser.Error
subclass directly from ConfigParser.read(), before [paths]/base is ever
touched. Only UnicodeDecodeError was caught there, so these raised a
raw configparser exception instead of the clean ValueError this
function otherwise produces for every other malformed-config case.

Fixes #44
Verified: pytest (366 passed), flake8 clean, mypy success.
