### PR TITLE
fix(verifier): enforce -l/--local and -k/--pubkey as mutually exclusive

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -104,6 +104,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     raw configparser exception for malformed INI syntax (duplicate
     section/option, a value line with no section header).
 
+  - fix: openbadges-verifier now enforces -l/--local and -k/--pubkey as
+    mutually exclusive (as documented in the CLI reference) instead of
+    silently letting -l win when both are given.
+
 
 * v1.1.5 - 2026-06-30
 

--- a/openbadgeslib/openbadges_verifier.py
+++ b/openbadgeslib/openbadges_verifier.py
@@ -72,11 +72,14 @@ def build_parser() -> argparse.ArgumentParser:
                         help='Specify the input file to verify the signature')
     parser.add_argument('-r', '--receptor', required=True,
                         help='Specify the email of the receptor of the badge')
-    parser.add_argument('-l', '--local', metavar='BADGE',
-                        help='Do the verification using the local configuration')
-    parser.add_argument('-k', '--pubkey', metavar='FILE',
-                        help='Path to the trusted PEM public key file used for '
-                             'verification (OB2 and OB3)')
+    trusted_key_group = parser.add_mutually_exclusive_group()
+    trusted_key_group.add_argument(
+        '-l', '--local', metavar='BADGE',
+        help='Do the verification using the local configuration')
+    trusted_key_group.add_argument(
+        '-k', '--pubkey', metavar='FILE',
+        help='Path to the trusted PEM public key file used for '
+             'verification (OB2 and OB3)')
     parser.add_argument('-s', '--show', action='store_true',
                         help='Show the assertion/credential of the OpenBadge being verified.')
     parser.add_argument('-V', '--ob-version', choices=['2', '3'], default='2',

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -209,6 +209,17 @@ def test_verifier_missing_file_exits(tmp_path):
             openbadges_verifier.main()
 
 
+def test_verifier_local_and_pubkey_are_mutually_exclusive():
+    # wiki/CLI-Reference.md documents -l/-k as mutually exclusive; enforce
+    # that in argparse itself instead of silently letting -l win.
+    import pytest
+    from openbadgeslib import openbadges_verifier
+    parser = openbadges_verifier.build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(['-i', 'badge.svg', '-r', 'r@example.com',
+                           '-l', '1', '-k', 'key.pem'])
+
+
 # ── openbadges-signer → openbadges-verifier (OB3 CLI roundtrip) ─────────────────
 
 def test_signer_ob3_then_verify_roundtrip(tmp_path, capsys):


### PR DESCRIPTION
wiki/CLI-Reference.md documents the two flags as mutually exclusive,
but build_parser() added them as independent optional arguments with
no runtime check, so passing both silently ignored --pubkey (--local
was checked first). Use argparse's mutually-exclusive group so the CLI
itself enforces the documented contract with a clean error instead of
silent precedence.

Fixes #45
Verified: pytest (367 passed), pytest tests/test_docs.py (8 passed),
flake8 clean, mypy success.
