### PR TITLE
fix(ob3): reject timezone-naive validFrom/validUntil dates

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,6 +6,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
 
 * Unreleased
 
+  - fix: OB3Verifier.verify() now rejects a vc.validFrom/validUntil claim that
+    parses as a timezone-naive ISO 8601 date-time instead of leaking a raw
+    TypeError when compared against the tz-aware expiration check.
+
   - fix: JWS header parsing (verify_block) now wraps malformed/non-object
     headers into SignatureError instead of leaking a raw json.JSONDecodeError,
     and every openbadgeslib._jws exception now inherits from

--- a/openbadgeslib/ob3/credential.py
+++ b/openbadgeslib/ob3/credential.py
@@ -244,4 +244,10 @@ def _parse_date(value: Any, where: str) -> datetime:
 
 def _parse_iso(s: str) -> datetime:
     """Parse an ISO 8601 date string, handling trailing Z."""
-    return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        # A date-time with no UTC/offset suffix is valid ISO 8601, but verify()
+        # always compares against an aware datetime.now(timezone.utc) — accept
+        # only unambiguously-anchored timestamps.
+        raise ValueError("date is missing a UTC offset: %r" % s)
+    return dt

--- a/tests/test_ob3_credential.py
+++ b/tests/test_ob3_credential.py
@@ -252,3 +252,11 @@ class TestHelpers:
         # _parse_iso's str.replace() call.
         with pytest.raises(ValueError):
             _parse_date(bad_value, 'vc.validFrom')
+
+    def test_parse_iso_naive_datetime_raises_value_error(self):
+        # A UTC/offset-less date-time is valid ISO 8601 but would produce a
+        # naive datetime that can't be compared against the tz-aware "now"
+        # used in verify() — reject it here instead of letting a TypeError
+        # surface downstream.
+        with pytest.raises(ValueError):
+            _parse_iso('2026-01-01T00:00:00')

--- a/tests/test_ob3_verifier.py
+++ b/tests/test_ob3_verifier.py
@@ -221,6 +221,16 @@ class TestOB3VerifierVerify:
         with pytest.raises(OB3VerificationError, match="ISO 8601"):
             ob3_rsa_verifier.verify(token)
 
+    @pytest.mark.parametrize('field', ['validFrom', 'validUntil'])
+    def test_timezone_naive_date_rejected(self, rsa_priv_pem, ob3_rsa_verifier, ob3_credential, field):
+        # A syntactically-valid ISO 8601 string with no UTC/offset suffix
+        # parses to a naive datetime, which must not leak a raw TypeError out
+        # of verify() when compared against the tz-aware "now".
+        token = self._signed_with_vc(rsa_priv_pem, ob3_credential,
+                                     lambda p: p['vc'].__setitem__(field, '2026-01-01T00:00:00'))
+        with pytest.raises(OB3VerificationError, match="ISO 8601"):
+            ob3_rsa_verifier.verify(token)
+
     # ── a non-object 'vc' claim, or a non-str/non-list 'vc.type', must not leak
     #    a raw AttributeError/TypeError out of verify() ────────────────────────
     @pytest.mark.parametrize('bad_vc', ['just-a-string', 12345, None, [], True])


### PR DESCRIPTION
verify() compared vc.validFrom/validUntil against a tz-aware "now",
raising a raw TypeError when the untrusted claim parsed as a
timezone-naive ISO 8601 date-time. _parse_iso now rejects offset-less
date-times so the error surfaces as the documented OB3VerificationError.

VERIFIED: pytest -q (370 passed), flake8, mypy all clean; reproduced the
raw TypeError before the fix and confirmed it now raises
OB3VerificationError.

Fixes #62
