### PR TITLE
fix(verifier): guard missing public_key file in --local path

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,6 +6,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
 
 * Unreleased
 
+  - fix: openbadges-verifier's --local option now checks the configured
+    public_key file exists before opening it, instead of leaking a raw
+    FileNotFoundError past the CLI's error handling.
+
   - fix: OB3Verifier.verify() now rejects a vc.validFrom/validUntil claim that
     parses as a timezone-naive ISO 8601 date-time instead of leaking a raw
     TypeError when compared against the tz-aware expiration check.

--- a/openbadgeslib/openbadges_verifier.py
+++ b/openbadgeslib/openbadges_verifier.py
@@ -53,7 +53,11 @@ def _resolve_trusted_pubkey(args: argparse.Namespace) -> Optional[bytes]:
     if args.local:
         conf = read_config_or_exit(args.config)
         section = resolve_badge_section(conf, args.local)
-        with open(conf[section]['public_key'], 'rb') as f:
+        key_path = conf[section]['public_key']
+        if not os.path.isfile(key_path):
+            print('[!] Public key file %s NOT exists.' % key_path)
+            sys.exit(-1)
+        with open(key_path, 'rb') as f:
             return f.read()
     if args.pubkey:
         if not os.path.isfile(args.pubkey):

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -209,6 +209,23 @@ def test_verifier_missing_file_exits(tmp_path):
             openbadges_verifier.main()
 
 
+def test_verifier_local_missing_pubkey_file_exits_cleanly(tmp_path):
+    # The --local branch of _resolve_trusted_pubkey must guard a missing
+    # public_key path the same way the --pubkey branch already does, instead
+    # of leaking a raw FileNotFoundError.
+    import argparse
+    import pytest
+    from openbadgeslib import openbadges_verifier
+
+    cfg = tmp_path / 'config.ini'
+    cfg.write_text(
+        '[paths]\nbase = .\n\n'
+        '[badge_missing]\npublic_key = %s\n' % (tmp_path / 'nonexistent.pem'))
+    args = argparse.Namespace(local='missing', pubkey=None, config=str(cfg))
+    with pytest.raises(SystemExit):
+        openbadges_verifier._resolve_trusted_pubkey(args)
+
+
 def test_verifier_local_and_pubkey_are_mutually_exclusive():
     # wiki/CLI-Reference.md documents -l/-k as mutually exclusive; enforce
     # that in argparse itself instead of silently letting -l win.


### PR DESCRIPTION
_resolve_trusted_pubkey's --local branch opened the configured
public_key file with no existence check, unlike the --pubkey branch a
few lines below, crashing openbadges-verifier with a raw
FileNotFoundError instead of a clean CLI error on a stale or
misconfigured config.ini.

VERIFIED: pytest -q (371 passed), flake8, mypy all clean; reproduced
the raw FileNotFoundError before the fix and confirmed a clean
SystemExit(-1) after.

Fixes #59
