### PR TITLE
fix(ob2): guard missing key files in Badge.create_from_conf()

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,6 +6,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
 
 * Unreleased
 
+  - fix: Badge.create_from_conf() now raises PrivateKeyReadError/
+    PublicKeyReadError instead of a raw FileNotFoundError/OSError when a
+    configured private_key/public_key path does not exist.
+
   - fix: openbadges-verifier's --local option now checks the configured
     public_key file exists before opening it, instead of leaking a raw
     FileNotFoundError past the CLI's error handling.

--- a/openbadgeslib/ob2/badge.py
+++ b/openbadgeslib/ob2/badge.py
@@ -148,11 +148,19 @@ class Badge():
         """ Create a Badge Object reading params from config.ini """
 
         """ Keys """
-        with open(conf[badge]['private_key'], 'rb') as key:
-            privkey_pem = key.read()
+        try:
+            with open(conf[badge]['private_key'], 'rb') as key:
+                privkey_pem = key.read()
+        except OSError as exc:
+            raise PrivateKeyReadError(
+                'Unable to read private key file %s: %s' % (conf[badge]['private_key'], exc)) from exc
 
-        with open(conf[badge]['public_key'], 'rb') as key:
-            pubkey_pem = key.read()
+        try:
+            with open(conf[badge]['public_key'], 'rb') as key:
+                pubkey_pem = key.read()
+        except OSError as exc:
+            raise PublicKeyReadError(
+                'Unable to read public key file %s: %s' % (conf[badge]['public_key'], exc)) from exc
 
         key_type = detect_key_type(pubkey_pem)
 

--- a/tests/test_signer_operation.py
+++ b/tests/test_signer_operation.py
@@ -10,7 +10,7 @@ from openbadgeslib.openbadges_signer import _safe_filename_component
 from openbadgeslib.badge import (Badge, BadgeType, BadgeImgType, Assertion,
                                  BadgeSigned, extract_svg_assertion,
                                  extract_png_assertion)
-from openbadgeslib.errors import ErrorSigningFile
+from openbadgeslib.errors import ErrorSigningFile, PrivateKeyReadError, PublicKeyReadError
 
 
 class check_badge(unittest.TestCase):
@@ -217,6 +217,26 @@ class check_signer(unittest.TestCase):
 
 
 # ── pytest-style tests using session fixtures from conftest.py ─────────────────
+
+
+class TestCreateFromConfMissingKeyFile:
+    """create_from_conf() must not leak a raw FileNotFoundError/OSError when a
+    configured key path is missing — it must raise the same LibOpenBadgesException
+    subclass Badge.__init__ already raises for corrupt-but-present key material."""
+
+    def test_missing_private_key_file_raises_clean_error(self):
+        cf = ConfParser('./config1.ini')
+        conf = cf.read_conf()
+        conf['badge_test_1']['private_key'] = '/nonexistent/priv.pem'
+        with pytest.raises(PrivateKeyReadError):
+            Badge.create_from_conf(conf, 'badge_test_1')
+
+    def test_missing_public_key_file_raises_clean_error(self):
+        cf = ConfParser('./config1.ini')
+        conf = cf.read_conf()
+        conf['badge_test_1']['public_key'] = '/nonexistent/pub.pem'
+        with pytest.raises(PublicKeyReadError):
+            Badge.create_from_conf(conf, 'badge_test_1')
 
 
 class TestSignBadgeRoundTrip:


### PR DESCRIPTION
create_from_conf() opened the configured private_key/public_key files
with no existence/permission guard, crashing openbadges-signer with a
raw FileNotFoundError instead of the PrivateKeyReadError/
PublicKeyReadError that Badge.__init__ already raises for corrupt-but-
present key material.

VERIFIED: pytest -q (373 passed), flake8, mypy all clean; reproduced
the raw FileNotFoundError before the fix and confirmed
PrivateKeyReadError/PublicKeyReadError after.

Fixes #60
