### PR TITLE
fix(ob2): wrap detect_key_type in Verifier.__init__

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,6 +6,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
 
 * Unreleased
 
+  - fix: OB2 Verifier.__init__ now raises VerifierExceptions instead of a raw
+    UnknownKeyType when a supplied verify_key is not a recognizable PEM key,
+    matching the guard OB3Verifier already has.
+
   - fix: Badge.create_from_conf() now raises PrivateKeyReadError/
     PublicKeyReadError instead of a raw FileNotFoundError/OSError when a
     configured private_key/public_key path does not exist.

--- a/openbadgeslib/ob2/verifier.py
+++ b/openbadgeslib/ob2/verifier.py
@@ -29,7 +29,7 @@ from ..keys import KeyType, detect_key_type
 from .._jws.exceptions import JWSException
 from .._jws import verify_block as jws_verify_block
 from .._jws import utils as jws_utils
-from ..errors import AssertionFormatIncorrect, NotIdentityInAssertion
+from ..errors import AssertionFormatIncorrect, NotIdentityInAssertion, UnknownKeyType, VerifierExceptions
 import json
 from urllib.error import HTTPError, URLError
 import logging
@@ -51,7 +51,10 @@ class Verifier():
         self.key_type = None
 
         if self.verify_key:
-            self.key_type = detect_key_type(self.verify_key)
+            try:
+                self.key_type = detect_key_type(self.verify_key)
+            except UnknownKeyType as exc:
+                raise VerifierExceptions(str(exc)) from exc
 
     def get_identity(self) -> Optional[str]:
         return self.identity.decode('utf-8') if self.identity is not None else None

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -226,6 +226,23 @@ def test_verifier_local_missing_pubkey_file_exits_cleanly(tmp_path):
         openbadges_verifier._resolve_trusted_pubkey(args)
 
 
+def test_verifier_garbage_pubkey_file_exits_cleanly(tmp_path, svg_rsa_badge, capsys):
+    # A non-PEM --pubkey file must be reported via the CLI's '[-] ...' error
+    # path (VerifierExceptions), not a raw traceback from detect_key_type().
+    import pytest
+    from openbadgeslib import openbadges_verifier
+    badge_file = _make_signed_ob2_svg(tmp_path, svg_rsa_badge)
+    garbage = tmp_path / 'garbage.pem'
+    garbage.write_bytes(b'this is not a pem key at all, just garbage text')
+
+    argv = ['openbadges-verifier', '-i', str(badge_file),
+            '-r', 'recipient@example.com', '-V', '2', '-k', str(garbage)]
+    with patch.object(sys, 'argv', argv):
+        with pytest.raises(SystemExit):
+            openbadges_verifier.main()
+    assert '[-]' in capsys.readouterr().out
+
+
 def test_verifier_local_and_pubkey_are_mutually_exclusive():
     # wiki/CLI-Reference.md documents -l/-k as mutually exclusive; enforce
     # that in argparse itself instead of silently letting -l win.

--- a/tests/test_verify_operation.py
+++ b/tests/test_verify_operation.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from openbadgeslib.verifier import Verifier
 from openbadgeslib.badge import BadgeStatus, BadgeSigned
+from openbadgeslib.errors import VerifierExceptions
 
 
 class TestCheckJWSSignature:
@@ -314,6 +315,16 @@ class TestCheckRevocation:
         with patch('openbadgeslib.ob2.verifier.download_file', side_effect=fake_download):
             with pytest.raises(AssertionFormatIncorrect):
                 v.check_revocation(badge)
+
+
+class TestVerifierConstructorKeyTypeValidation:
+    def test_garbage_verify_key_raises_verifier_exception(self):
+        # detect_key_type() raises the sibling KeyGenExceptions.UnknownKeyType,
+        # not a VerifierExceptions — the constructor must translate it so the
+        # CLI's `except VerifierExceptions` clause can catch it cleanly.
+        with pytest.raises(VerifierExceptions):
+            Verifier(verify_key=b'this is not a pem key at all, just garbage text',
+                     identity='foo@example.com')
 
 
 class TestEmbeddedKeyFallback:


### PR DESCRIPTION
Verifier.__init__ called detect_key_type() with no try/except, letting
a raw UnknownKeyType (a KeyGenExceptions, not a VerifierExceptions)
escape past the CLI's `except VerifierExceptions` clause and crash
with a traceback on a non-PEM verify_key. OB3Verifier already guards
the identical call; mirror that here.

VERIFIED: pytest -q (375 passed), flake8, mypy all clean; reproduced
the raw UnknownKeyType before the fix and confirmed a clean
VerifierExceptions/CLI '[-] ...' exit after.

Fixes #61
