### PR TITLE
fix(ob3): catch PyJWT errors in OB3Signer.sign()

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,6 +6,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
 
 * Unreleased
 
+  - fix: OB3Signer.sign() now raises ErrorSigningFile instead of leaking a
+    raw jwt.exceptions.InvalidKeyError when the requested algorithm doesn't
+    match the given key's type.
+
   - fix: OB3Verifier.extract_token_from_png() now raises ErrorParsingFile
     instead of leaking a raw UnicodeDecodeError when a PNG's "openbadges"
     iTXt chunk contains malformed UTF-8 text.

--- a/openbadgeslib/ob3/signer.py
+++ b/openbadgeslib/ob3/signer.py
@@ -56,7 +56,11 @@ class OB3Signer:
     def sign(self, credential: OpenBadgeCredential) -> str:
         """Sign a credential and return a compact JWT-VC string."""
         payload = credential.to_jwt_payload()
-        return jwt.encode(payload, self.privkey_pem, algorithm=self.algorithm)
+        try:
+            return jwt.encode(payload, self.privkey_pem, algorithm=self.algorithm)
+        except jwt.exceptions.PyJWTError as exc:
+            raise ErrorSigningFile(
+                "Could not sign credential with algorithm %s: %s" % (self.algorithm, exc)) from exc
 
     # ── image baking ───────────────────────────────────────────────────────────
 

--- a/tests/test_ob3_signer.py
+++ b/tests/test_ob3_signer.py
@@ -3,6 +3,7 @@ import pytest
 from xml.dom.minidom import parseString
 
 from openbadgeslib.ob3 import OB3Signer
+from openbadgeslib.errors import ErrorSigningFile
 
 
 # ── OB3Signer construction ─────────────────────────────────────────────────────
@@ -80,6 +81,18 @@ class TestOB3SignerSign:
         assert 'vc' in payload
         assert payload['iss'] == ob3_credential.issuer.id
         assert payload['sub'] == ob3_credential.recipient_id
+
+    def test_sign_rsa_key_with_ecc_algorithm_raises_clean_error(self, rsa_priv_pem, ob3_credential):
+        # A supported-but-mismatched algorithm/key-type pair must not leak a
+        # raw jwt.exceptions.InvalidKeyError out of sign().
+        signer = OB3Signer(privkey_pem=rsa_priv_pem, algorithm='ES256')
+        with pytest.raises(ErrorSigningFile):
+            signer.sign(ob3_credential)
+
+    def test_sign_ecc_key_with_rsa_algorithm_raises_clean_error(self, ecc_priv_pem, ob3_credential):
+        signer = OB3Signer(privkey_pem=ecc_priv_pem, algorithm='RS256')
+        with pytest.raises(ErrorSigningFile):
+            signer.sign(ob3_credential)
 
 
 # ── sign_into_svg() ────────────────────────────────────────────────────────────


### PR DESCRIPTION
sign() called jwt.encode() with no try/except, letting a raw
jwt.exceptions.InvalidKeyError (not a LibOpenBadgesException) escape
when the requested algorithm doesn't match the given key's type (e.g.
an RSA key with algorithm='ES256').

VERIFIED: pytest -q (378 passed), flake8, mypy all clean; reproduced
the raw InvalidKeyError before the fix and confirmed ErrorSigningFile
after.

Fixes #63
