### PR TITLE
fix(signer): report SMTP auth misconfiguration cleanly

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,6 +6,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
 
 * Unreleased
 
+  - fix: openbadges-signer's -M/--mail-badge now reports a clean error
+    instead of crashing when config.ini sets an SMTP username without
+    use_ssl=True; the already-signed badge is still saved.
+
   - fix: OB3Signer.sign() now raises ErrorSigningFile instead of leaking a
     raw jwt.exceptions.InvalidKeyError when the requested algorithm doesn't
     match the given key's type.

--- a/openbadgeslib/openbadges_signer.py
+++ b/openbadgeslib/openbadges_signer.py
@@ -163,11 +163,17 @@ def _sign_ob2(args: argparse.Namespace, conf: configparser.ConfigParser, badge: 
             username = conf['smtp'].get('username')
             password = conf['smtp'].get('password')
 
-            mail = BadgeMail(server, port, use_ssl, mail_from, username, password)
-            subject, body = mail.get_mail_content(conf[badge]['mail'])
-            mail.set_subject(subject)
-            mail.set_body(body)
-            mail.send(badge_signed)
+            try:
+                mail = BadgeMail(server, port, use_ssl, mail_from, username, password)
+                subject, body = mail.get_mail_content(conf[badge]['mail'])
+                mail.set_subject(subject)
+                mail.set_body(body)
+                mail.send(badge_signed)
+            except ValueError as err:
+                # e.g. a username set without use_ssl=True — the badge is
+                # already signed and saved, so report the config error
+                # instead of crashing with a traceback.
+                print('[!] Could not send mail: %s' % err)
 
         print('%s at: %s' % (msg.strip('\n'), badge_file_out))
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -542,6 +542,26 @@ def test_signer_ob2_mail_badge_sends(tmp_path):
     smtp.sendmail.assert_called_once()
 
 
+def test_signer_ob2_mail_badge_auth_without_ssl_reports_clean_error(tmp_path, capsys):
+    # BadgeMail.__init__ raises a bare ValueError when username is set but
+    # use_ssl is not True. The CLI must report it cleanly (the badge is
+    # already signed and saved) instead of crashing with a raw traceback.
+    from openbadgeslib import openbadges_signer
+    cfg = _write_ob2_sign_config(tmp_path)
+    cfg.write_text(cfg.read_text().replace(
+        'mail_from = no-reply@example.com\n',
+        'mail_from = no-reply@example.com\nusername = user\npassword = pass\n'))
+    argv = ['openbadges-signer', '-c', str(cfg), '-b', '1',
+            '-r', 'recipient@example.com', '-o', str(tmp_path), '-V', '2', '-E', '-M']
+    with patch('openbadgeslib.ob2.badge.download_file', return_value=b'data'), \
+            patch.object(sys, 'argv', argv):
+        openbadges_signer.main()   # must not raise
+    out = capsys.readouterr().out
+    assert '[!] Could not send mail' in out
+    signed = list(tmp_path.glob('badge_1_recipient@example.com.*'))
+    assert signed, "badge must still be saved even though mailing failed"
+
+
 def test_signer_requires_evidence_choice(tmp_path):
     import pytest
     from openbadgeslib import openbadges_signer


### PR DESCRIPTION
BadgeMail.__init__() raises a bare ValueError when a username is
configured without use_ssl=True. _sign_ob2()'s -M mail block had no
try/except around it, crashing openbadges-signer with a raw traceback
after the badge was already signed and saved to disk.

VERIFIED: pytest -q (379 passed), flake8, mypy all clean; reproduced
the raw ValueError before the fix and confirmed a clean '[!] ...'
message (with the badge still saved) after.

Fixes #65
