### PR TITLE
refactor(ob2): drop unused Verifier.key_type attribute

### DIFF
--- a/openbadgeslib/ob2/verifier.py
+++ b/openbadgeslib/ob2/verifier.py
@@ -48,11 +48,14 @@ class Verifier():
                  identity: Optional[str] = None) -> None:
         self.verify_key = verify_key
         self.identity = identity.encode('utf-8') if identity is not None else None
-        self.key_type = None
 
         if self.verify_key:
+            # Not stored: the actual alg-pinning security control
+            # (_allowed_algs_for_key) re-derives the key type itself from the
+            # key it verifies against. This call exists only to reject an
+            # unrecognizable verify_key early, with a clean exception.
             try:
-                self.key_type = detect_key_type(self.verify_key)
+                detect_key_type(self.verify_key)
             except UnknownKeyType as exc:
                 raise VerifierExceptions(str(exc)) from exc
 


### PR DESCRIPTION
detect_key_type()'s result was stored but never read anywhere else —
the actual alg-pinning check re-derives the key type itself from the
key it verifies against. Keep the call for its early-validation
side effect, drop the dead attribute.

VERIFIED: pytest -q (379 passed), flake8, mypy all clean; grepped for
Verifier.key_type readers, found none.

Fixes #64
