### PR TITLE
docs: fix keygenerator example issuer name mismatch

### DIFF
--- a/wiki/CLI-Reference.md
+++ b/wiki/CLI-Reference.md
@@ -53,7 +53,7 @@ The command refuses to overwrite: if either key file already exists it prints `[
 
 ```sh
 $ openbadges-keygenerator -c ./config/config.ini -g 1
-INFO - Generating OpenBadges 2 RSA key pair for issuer 'My Organisation'
+INFO - Generating OpenBadges 2 RSA key pair for issuer 'OpenBadge issuer'
 INFO - Private key saved at: ./config/keys/sign_rsa_key_1.pem
 INFO - Public key saved at:  ./config/keys/verify_rsa_key_1.pem
 ```

--- a/wiki/Quick-Start.md
+++ b/wiki/Quick-Start.md
@@ -19,7 +19,7 @@ openbadges-keygenerator -c ./config/config.ini -g 1
 ```
 
 ```
-INFO - Generating OpenBadges 2 RSA key pair for issuer 'My Organisation'
+INFO - Generating OpenBadges 2 RSA key pair for issuer 'OpenBadge issuer'
 INFO - Private key saved at: ./config/keys/sign_rsa_key_1.pem
 INFO - Public key saved at:  ./config/keys/verify_rsa_key_1.pem
 ```


### PR DESCRIPTION
Both example transcripts showed issuer 'My Organisation', which
appears nowhere in the shipped config.ini.example (default is
'OpenBadge issuer') and doesn't match what running the documented
commands verbatim actually prints.

VERIFIED: pytest tests/test_docs.py -q; reproduced the documented
command sequence and confirmed the actual log line now matches.

Fixes #67
