### PR TITLE
docs: cover redirect downgrade rejection and size cap

### DIFF
--- a/wiki/Security-Model.md
+++ b/wiki/Security-Model.md
@@ -56,7 +56,7 @@ if u.scheme != 'https':
         raise ValueError('Refusing to download ... HTTPS is required ...')
 ```
 
-TLS certificate validation is on (urllib's default context), downloads time out after 30 seconds, and plain HTTP is only ever used if a caller explicitly passes `allow_insecure=True`.
+TLS certificate validation is on (urllib's default context), downloads time out after 30 seconds, and plain HTTP is only ever used if a caller explicitly passes `allow_insecure=True`. A redirect to a non-HTTPS target is also rejected — an HTTPS URL can't be silently downgraded via a 302 — and the response body is capped at 5 MiB to bound memory use against an oversized or attacker-influenced response.
 
 ### defusedxml for SVG (billion-laughs)
 


### PR DESCRIPTION
Security-Model.md's HTTPS-only downloads section described the
initial-URL scheme check but omitted two protections download_file()
already implements: rejecting a redirect to a non-HTTPS target, and
capping the response body at 5 MiB.

VERIFIED: pytest tests/test_docs.py -q.

Fixes #68
