### PR TITLE
security(jws): treat a private verify key as a failed signature

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,6 +6,11 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
 
 * Unreleased
 
+  - SECURITY: _jws.verify_block() now treats an RSA private key supplied
+    where a public verify key is expected as a failed signature
+    (SignatureError) instead of crashing with a raw AttributeError — closes
+    a remotely-triggerable crash on the badge-embedded-key OB2 fallback path.
+
   - fix: openbadges-signer's -M/--mail-badge now reports a clean error
     instead of crashing when config.ini sets an SMTP username without
     use_ssl=True; the already-signed badge is still saved.

--- a/openbadgeslib/_jws/__init__.py
+++ b/openbadgeslib/_jws/__init__.py
@@ -104,7 +104,11 @@ def verify_block(msg: Union[str, bytes], key: Optional[Any] = None) -> bool:
     try:
         prepared = algo.prepare_key(key_to_pem(key))
         valid = algo.verify(signing_input, prepared, raw_sig)
-    except (InvalidKeyError, ValueError) as exc:
+    except (InvalidKeyError, ValueError, AttributeError, TypeError) as exc:
+        # A private key served where a public key is expected reaches
+        # RSAAlgorithm.verify() as an RSAPrivateKey, which has no .verify()
+        # method — PyJWT lets the resulting AttributeError escape. Treat any
+        # such key/algorithm mismatch as a failed signature, never a crash.
         raise SignatureError(str(exc)) from exc
 
     if not valid:

--- a/tests/test_jws.py
+++ b/tests/test_jws.py
@@ -78,6 +78,20 @@ class TestRSARoundTrip:
         with pytest.raises((SignatureError, Exception)):
             verify_block(jws, key=pub)
 
+    def test_rsa_private_key_as_verify_key_raises_signature_error(self, rsa_priv_pem):
+        # A malicious verify.url can serve an RSA *private* key PEM. It parses
+        # as an RSA key, but PyJWT's RSAAlgorithm.verify() then calls .verify()
+        # on an RSAPrivateKey (which lacks it), raising AttributeError. That
+        # must surface as a SignatureError, never a raw crash.
+        from openbadgeslib.keys import KeyRSA
+        k = KeyRSA()
+        k.read_private_key(rsa_priv_pem)
+        priv = k.get_priv_key()
+        raw_sig = sign({'alg': 'RS256'}, PAYLOAD, key=priv)
+        jws = _build_jws({'alg': 'RS256'}, PAYLOAD, raw_sig)
+        with pytest.raises(SignatureError):
+            verify_block(jws, key=priv)
+
 
 class TestECCRoundTrip:
     def test_sign_returns_bytes(self, ecc_priv_pem, ecc_pub_pem):


### PR DESCRIPTION
verify_block() only caught (InvalidKeyError, ValueError) around
algo.verify(). A malicious verify.url can serve an RSA private key PEM;
PyJWT's RSAAlgorithm.verify() then calls .verify() on an RSAPrivateKey,
which lacks it, raising a raw AttributeError that escaped uncaught —
a remotely-triggerable crash on the default badge-embedded-key OB2
fallback path. Broaden the except to map any such key/algorithm
mismatch to SignatureError.

VERIFIED: pytest -q (380 passed), flake8, mypy all clean; confirmed the
inner exception is an uncaught AttributeError pre-fix and a clean
SignatureError after.

Fixes #79
