### PR TITLE
fix(ob2): validate revocation URL fields are strings

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,6 +6,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
 
 * Unreleased
 
+  - fix: OB2 check_revocation() now raises AssertionFormatIncorrect instead
+    of a raw AttributeError when the badge/issuer JSON carries a non-string
+    'badge'/'issuer'/'revocationList' URL field.
+
   - SECURITY: _jws.verify_block() now treats an RSA private key supplied
     where a public verify key is expected as a failed signature
     (SignatureError) instead of crashing with a raw AttributeError — closes

--- a/openbadgeslib/ob2/verifier.py
+++ b/openbadgeslib/ob2/verifier.py
@@ -125,6 +125,11 @@ class Verifier():
 
         serial_num = str(badge.serial_num)
         json_url = badge.source.json_url
+        if not isinstance(json_url, str):
+            # json_url comes from the untrusted assertion body's 'badge' field;
+            # a non-string would raise a raw AttributeError inside download_file.
+            raise AssertionFormatIncorrect(
+                "Badge 'badge' URL is not a string: %r" % (json_url,))
 
         badge_json = download_file(json_url)
         if not badge_json:
@@ -137,9 +142,9 @@ class Verifier():
             raise AssertionFormatIncorrect("Badge JSON at %s is not a JSON object" % json_url)
 
         issuer_url = badge_obj.get('issuer')
-        if not issuer_url:
+        if not issuer_url or not isinstance(issuer_url, str):
             raise AssertionFormatIncorrect(
-                "Badge JSON at %s has no 'issuer' URL" % json_url)
+                "Badge JSON at %s has no valid 'issuer' URL" % json_url)
         issuer_json = download_file(issuer_url)
         if not issuer_json:
             raise AssertionFormatIncorrect("Issuer JSON doesn't exist %s" % issuer_url)
@@ -155,6 +160,9 @@ class Verifier():
         revocation_url = issuer.get('revocationList')
         if not revocation_url:
             return None
+        if not isinstance(revocation_url, str):
+            raise AssertionFormatIncorrect(
+                "Issuer JSON at %s has a non-string 'revocationList' URL" % issuer_url)
 
         revocation_json = download_file(revocation_url)
         if not revocation_json:

--- a/tests/test_verify_operation.py
+++ b/tests/test_verify_operation.py
@@ -316,6 +316,44 @@ class TestCheckRevocation:
             with pytest.raises(AssertionFormatIncorrect):
                 v.check_revocation(badge)
 
+    def test_non_string_issuer_url_raises_clean_error(self, badge_for_verify_rsa):
+        # A non-string 'issuer' URL must not reach download_file()/urlparse()
+        # and leak a raw AttributeError.
+        import json as _json
+        from openbadgeslib.errors import AssertionFormatIncorrect
+        badge, identity = badge_for_verify_rsa
+        v = Verifier(identity=identity)
+        with patch('openbadgeslib.ob2.verifier.download_file',
+                   return_value=_json.dumps({'issuer': 12345}).encode()):
+            with pytest.raises(AssertionFormatIncorrect):
+                v.check_revocation(badge)
+
+    def test_non_string_revocation_url_raises_clean_error(self, badge_for_verify_rsa):
+        import json as _json
+        from openbadgeslib.errors import AssertionFormatIncorrect
+        badge, identity = badge_for_verify_rsa
+        v = Verifier(identity=identity)
+        badge_json = {'issuer': 'https://example.com/issuer.json'}
+
+        def fake_download(url, *a, **k):
+            if url == badge.source.json_url:
+                return _json.dumps(badge_json).encode()
+            return _json.dumps({'revocationList': 12345}).encode()
+
+        with patch('openbadgeslib.ob2.verifier.download_file', side_effect=fake_download):
+            with pytest.raises(AssertionFormatIncorrect):
+                v.check_revocation(badge)
+
+    def test_non_string_json_url_raises_clean_error(self, badge_for_verify_rsa):
+        # badge.source.json_url comes from the untrusted assertion 'badge'
+        # field; a non-string must not leak a raw AttributeError.
+        from openbadgeslib.errors import AssertionFormatIncorrect
+        badge, identity = badge_for_verify_rsa
+        v = Verifier(identity=identity)
+        with patch.object(badge.source, 'json_url', 12345):
+            with pytest.raises(AssertionFormatIncorrect):
+                v.check_revocation(badge)
+
 
 class TestVerifierConstructorKeyTypeValidation:
     def test_garbage_verify_key_raises_verifier_exception(self):


### PR DESCRIPTION
check_revocation() only truthiness-checked json_url/issuer/revocationList
before handing them to download_file(), whose urlparse() call raises a
raw AttributeError on a non-string. A crafted badge/issuer JSON could
thus crash get_badge_status() and the CLI. Validate isinstance(str) on
all three URL fields, raising AssertionFormatIncorrect — matching the
existing isinstance(dict) guards on the parsed JSON bodies.

VERIFIED: pytest -q (383 passed), flake8, mypy all clean; reproduced the
raw AttributeError before the fix and confirmed AssertionFormatIncorrect
after for all three fields.

Fixes #80
