### PR TITLE
fix(ob3): reject non-string required id/name fields

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,6 +6,11 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
 
 * Unreleased
 
+  - fix: OB3 credential parsing now rejects a non-string required id/name
+    field (vc.id, issuer.id, credentialSubject.id, achievement.id/name) with
+    a clean OB3VerificationError, instead of leaking a raw AttributeError out
+    of verify() when recipient binding lower-cases the id.
+
   - fix: OB2 check_revocation() now raises AssertionFormatIncorrect instead
     of a raw AttributeError when the badge/issuer JSON carries a non-string
     'badge'/'issuer'/'revocationList' URL field.

--- a/openbadgeslib/ob3/credential.py
+++ b/openbadgeslib/ob3/credential.py
@@ -225,11 +225,16 @@ def _as_dict_or_empty(value: Any) -> dict:
     return value if isinstance(value, dict) else {}
 
 
-def _require(data: dict, key: str, where: str) -> Any:
-    """Return data[key], raising a clear ValueError if missing or empty."""
+def _require(data: dict, key: str, where: str) -> str:
+    """Return data[key] as a string, raising a clear ValueError if missing,
+    empty, or not a string. All fields validated here (id/name) are identifiers
+    consumed as strings downstream (e.g. recipient binding calls .lower()), so a
+    non-string value must be rejected rather than crash later."""
     value = data.get(key)
     if value is None or value == "":
         raise ValueError("missing required field %s.%s" % (where, key))
+    if not isinstance(value, str):
+        raise ValueError("field %s.%s must be a string" % (where, key))
     return value
 
 

--- a/tests/test_ob3_credential.py
+++ b/tests/test_ob3_credential.py
@@ -5,6 +5,7 @@ import pytest
 
 from openbadgeslib.ob3.credential import (
     Achievement, Issuer, OpenBadgeCredential, OB3_CONTEXT, _iso, _parse_iso, _parse_date,
+    _require,
 )
 
 
@@ -260,3 +261,10 @@ class TestHelpers:
         # surface downstream.
         with pytest.raises(ValueError):
             _parse_iso('2026-01-01T00:00:00')
+
+    @pytest.mark.parametrize('bad_value', [12345, True, ['a'], {'x': 1}])
+    def test_require_non_string_raises_value_error(self, bad_value):
+        # id/name fields are consumed as strings downstream (recipient binding
+        # calls .lower()); a non-string must be rejected here.
+        with pytest.raises(ValueError, match="must be a string"):
+            _require({'id': bad_value}, 'id', 'vc.credentialSubject')

--- a/tests/test_ob3_verifier.py
+++ b/tests/test_ob3_verifier.py
@@ -248,6 +248,37 @@ class TestOB3VerifierVerify:
         with pytest.raises(OB3VerificationError, match="OpenBadgeCredential"):
             ob3_rsa_verifier.verify(token)
 
+    # ── a non-string id/name field (consumed downstream as a string, e.g.
+    #    recipient binding calls .lower()) must not leak a raw AttributeError ───
+    @pytest.mark.parametrize('bad_id', [12345, True, ['a'], {'x': 1}])
+    def test_non_string_credential_subject_id_rejected(
+        self, rsa_priv_pem, ob3_rsa_verifier, ob3_credential, bad_id
+    ):
+        token = self._signed_with_vc(
+            rsa_priv_pem, ob3_credential,
+            lambda p: p['vc']['credentialSubject'].__setitem__('id', bad_id))
+        # Rejected even without expected_recipient (at credential-build time).
+        with pytest.raises(OB3VerificationError, match="must be a string"):
+            ob3_rsa_verifier.verify(token)
+
+    def test_non_string_credential_subject_id_with_expected_recipient_rejected(
+        self, rsa_priv_pem, ob3_rsa_verifier, ob3_credential
+    ):
+        # The documented recipient-binding path (-r/--receptor) must surface a
+        # clean OB3VerificationError, not a raw AttributeError from .lower().
+        token = self._signed_with_vc(
+            rsa_priv_pem, ob3_credential,
+            lambda p: p['vc']['credentialSubject'].__setitem__('id', 12345))
+        with pytest.raises(OB3VerificationError):
+            ob3_rsa_verifier.verify(token, expected_recipient='someone@example.com')
+
+    def test_non_string_issuer_id_rejected(self, rsa_priv_pem, ob3_rsa_verifier, ob3_credential):
+        token = self._signed_with_vc(
+            rsa_priv_pem, ob3_credential,
+            lambda p: p['vc']['issuer'].__setitem__('id', 12345))
+        with pytest.raises(OB3VerificationError, match="must be a string"):
+            ob3_rsa_verifier.verify(token)
+
     # ── array credentialSubject: the sub cross-check must normalise the list to
     #    its first element, not call .get() on the list (which raised a raw
     #    AttributeError that escaped verify()) ─────────────────────────────────


### PR DESCRIPTION
_require() only rejected None/'' — a non-string vc.id / issuer.id /
credentialSubject.id / achievement.id/name passed validation and was
stored as recipient_id, then leaked a raw AttributeError out of verify()
when recipient_ids_match() called .lower() on it. Reject non-strings
here; from_jwt_payload() already maps the ValueError to a clean
OB3VerificationError.

VERIFIED: pytest -q (393 passed), flake8, mypy all clean; reproduced the
raw AttributeError before the fix and confirmed OB3VerificationError
after, with and without expected_recipient.

Fixes #81
