### PR TITLE
fix(signer): catch OSError/KeyError in the -M mail block

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -22,7 +22,9 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
 
   - fix: openbadges-signer's -M/--mail-badge now reports a clean error
     instead of crashing when config.ini sets an SMTP username without
-    use_ssl=True; the already-signed badge is still saved.
+    use_ssl=True, when the mail template file is missing/unreadable
+    (OSError), or when the badge section has no 'mail' key (KeyError); the
+    already-signed badge is still saved in every case.
 
   - fix: OB3Signer.sign() now raises ErrorSigningFile instead of leaking a
     raw jwt.exceptions.InvalidKeyError when the requested algorithm doesn't

--- a/openbadgeslib/openbadges_signer.py
+++ b/openbadgeslib/openbadges_signer.py
@@ -169,10 +169,12 @@ def _sign_ob2(args: argparse.Namespace, conf: configparser.ConfigParser, badge: 
                 mail.set_subject(subject)
                 mail.set_body(body)
                 mail.send(badge_signed)
-            except ValueError as err:
-                # e.g. a username set without use_ssl=True — the badge is
-                # already signed and saved, so report the config error
-                # instead of crashing with a traceback.
+            except (ValueError, OSError, KeyError) as err:
+                # e.g. a username set without use_ssl=True (ValueError), a
+                # missing/unreadable mail template file (OSError), or a badge
+                # section with no 'mail' key (KeyError) — the badge is already
+                # signed and saved, so report the config error instead of
+                # crashing with a traceback.
                 print('[!] Could not send mail: %s' % err)
 
         print('%s at: %s' % (msg.strip('\n'), badge_file_out))

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -562,6 +562,26 @@ def test_signer_ob2_mail_badge_auth_without_ssl_reports_clean_error(tmp_path, ca
     assert signed, "badge must still be saved even though mailing failed"
 
 
+def test_signer_ob2_mail_badge_missing_template_reports_clean_error(tmp_path, capsys):
+    # A missing/unreadable mail template file makes get_mail_content() raise
+    # OSError. The CLI must report it cleanly (the badge is already signed and
+    # saved) instead of crashing with a raw traceback.
+    from openbadgeslib import openbadges_signer
+    cfg = _write_ob2_sign_config(tmp_path)
+    cfg.write_text(cfg.read_text().replace(
+        'mail = %s\n' % (tmp_path / 'badgemail.txt'),
+        'mail = %s\n' % (tmp_path / 'nonexistent-mail.txt')))
+    argv = ['openbadges-signer', '-c', str(cfg), '-b', '1',
+            '-r', 'recipient@example.com', '-o', str(tmp_path), '-V', '2', '-E', '-M']
+    with patch('openbadgeslib.ob2.badge.download_file', return_value=b'data'), \
+            patch.object(sys, 'argv', argv):
+        openbadges_signer.main()   # must not raise
+    out = capsys.readouterr().out
+    assert '[!] Could not send mail' in out
+    signed = list(tmp_path.glob('badge_1_recipient@example.com.*'))
+    assert signed, "badge must still be saved even though mailing failed"
+
+
 def test_signer_requires_evidence_choice(tmp_path):
     import pytest
     from openbadgeslib import openbadges_signer


### PR DESCRIPTION
The -M/--mail-badge block only caught ValueError. A missing/unreadable
mail template file (get_mail_content raises OSError) or a badge section
without a 'mail' key (KeyError) crashed openbadges-signer with a raw
traceback after the badge was already signed and saved. Broaden the
except to (ValueError, OSError, KeyError).

VERIFIED: pytest -q (394 passed), flake8, mypy all clean; reproduced the
raw OSError before the fix and confirmed a clean '[!] Could not send
mail' message (badge still saved) after.

Fixes #82
