### PR TITLE
fix(cli): exit cleanly when init/publish target exists

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,6 +6,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
 
 * Unreleased
 
+  - fix: openbadges-init and openbadges-publish now exit cleanly with a
+    '[!] <path> already exists' message instead of a raw FileExistsError
+    traceback when the target directory/output path already exists.
+
   - fix: OB3 credential parsing now rejects a non-string required id/name
     field (vc.id, issuer.id, credentialSubject.id, achievement.id/name) with
     a clean OB3VerificationError, instead of leaking a raw AttributeError out

--- a/openbadgeslib/openbadges_init.py
+++ b/openbadgeslib/openbadges_init.py
@@ -42,7 +42,7 @@ def main() -> None:
     directory = sys.argv[1]
 
     if os.path.lexists(directory):
-        raise FileExistsError(directory)
+        sys.exit('[!] %s already exists' % directory)
 
     umask = os.umask(0o077)  # rwx------
     try:

--- a/openbadgeslib/openbadges_publish.py
+++ b/openbadgeslib/openbadges_publish.py
@@ -35,6 +35,7 @@ import json
 import os
 import os.path
 import shutil
+import sys
 
 from urllib.parse import urljoin
 from .confparser import read_config_or_exit
@@ -67,7 +68,7 @@ def main() -> None:
 
     if args.output:
         if os.path.lexists(args.output):
-            raise FileExistsError(args.output)
+            sys.exit('[!] %s already exists' % args.output)
 
         umask = os.umask(0o077)  # rwx------
         try:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -16,6 +16,18 @@ def test_init_creates_directory_layout(tmp_path):
         assert (target / sub).is_dir()
 
 
+def test_init_existing_directory_exits_cleanly(tmp_path):
+    # Re-running openbadges-init against an existing path must exit cleanly
+    # (SystemExit) with an operator-facing message, not a raw FileExistsError.
+    import pytest
+    from openbadgeslib import openbadges_init
+    target = tmp_path / 'config'
+    target.mkdir()
+    with patch.object(sys, 'argv', ['openbadges-init', str(target)]):
+        with pytest.raises(SystemExit):
+            openbadges_init.main()
+
+
 def test_init_creates_directories_with_restrictive_permissions(tmp_path):
     # The keys/ subdirectory will hold private key material; openbadges_init
     # applies a 0o077 umask around the mkdir calls so every created directory
@@ -300,6 +312,19 @@ def test_publish_ob2_creates_full_tree(tmp_path):
     for name in ('badge_test_1', 'badge_test_2', 'badge_test_3', 'badge_test_4'):
         assert (out / name / 'badge.json').is_file()
         assert (out / name / 'verify.pem').is_file()
+
+
+def test_publish_existing_output_exits_cleanly(tmp_path):
+    # -o pointing at an existing path must exit cleanly (SystemExit) with an
+    # operator-facing message, not a raw FileExistsError.
+    import pytest
+    from openbadgeslib import openbadges_publish
+    out = tmp_path / 'published'
+    out.mkdir()
+    argv = ['openbadges-publish', '-c', './config1.ini', '-o', str(out)]
+    with patch.object(sys, 'argv', argv):
+        with pytest.raises(SystemExit):
+            openbadges_publish.main()
 
 
 def test_publish_restores_umask_when_a_badge_mkdir_fails(tmp_path):


### PR DESCRIPTION
openbadges-init and openbadges-publish raised a raw FileExistsError out
of main() when their target path already existed, unlike every other
validation failure in these CLIs (which print '[!] ...' + sys.exit(-1)).
Replace both with a clean sys.exit message.

VERIFIED: pytest -q (396 passed), flake8, mypy all clean; reproduced the
raw FileExistsError traceback before the fix and confirmed a clean
SystemExit after for both tools.

Fixes #83
