### PR TITLE
fix(ob2): guard read_from_file against a non-object JWS body

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,6 +6,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
 
 * Unreleased
 
+  - fix: BadgeSigned.read_from_file() now raises AssertionFormatIncorrect
+    instead of a raw TypeError/AttributeError when the JWS body decodes to a
+    valid-JSON non-object (array, string, number, or null).
+
   - fix: openbadges-init and openbadges-publish now exit cleanly with a
     '[!] <path> already exists' message instead of a raw FileExistsError
     traceback when the target directory/output path already exists.

--- a/openbadgeslib/ob2/badge.py
+++ b/openbadgeslib/ob2/badge.py
@@ -269,6 +269,12 @@ class BadgeSigned():
             raise BadgeImgFormatUnsupported('The image format for %s is not supported' % file_name)
 
         body = assertion.decode_body()
+        if not isinstance(body, dict):
+            # The body can decode to any JSON value; a non-object would raise a
+            # raw TypeError/AttributeError on the field accesses below, before
+            # the guarded construction block further down.
+            raise AssertionFormatIncorrect(
+                'OpenBadge assertion body is not a JSON object')
 
         try:
             evidence = body['evidence']

--- a/tests/test_badge_io.py
+++ b/tests/test_badge_io.py
@@ -250,6 +250,29 @@ class TestBadgeSignedReadFromFile:
             with pytest.raises(ErrorParsingFile):
                 BadgeSigned.read_from_file(path)
 
+    def _badge_with_raw_body(self, tmp_path, signed_svg_rsa, svg_image, raw_body):
+        """Bake a badge whose JWS body is an arbitrary (possibly non-object)
+        JSON value, not a mutated copy of the original dict."""
+        from openbadgeslib._jws import utils as jws_utils
+
+        assertion = extract_svg_assertion(signed_svg_rsa.signed)
+        new_body_b64 = jws_utils.encode(raw_body)
+        tampered = assertion.header + b'.' + new_body_b64 + b'.' + assertion.signature
+        baked = baking.bake_svg(svg_image, tampered.decode('utf-8'))
+        return self._write_temp(tmp_path, baked, '.svg')
+
+    @pytest.mark.parametrize('raw_body', [[1, 2, 3], 'just-a-string', 42, None, True])
+    def test_non_object_body_raises_clean_error(
+        self, tmp_path, signed_svg_rsa, svg_image, rsa_pub_pem, raw_body
+    ):
+        # A body that decodes to a valid-JSON non-object must not leak a raw
+        # TypeError/AttributeError from the field accesses before the guarded
+        # construction block.
+        path = self._badge_with_raw_body(tmp_path, signed_svg_rsa, svg_image, raw_body)
+        with patch('openbadgeslib.ob2.badge.download_file', return_value=rsa_pub_pem):
+            with pytest.raises(AssertionFormatIncorrect):
+                BadgeSigned.read_from_file(path)
+
 
 class TestBadgeInitCorruptKey:
     """A corrupt/mismatched private key must not leak a raw ValueError/binascii.Error."""


### PR DESCRIPTION
decode_body() can return any JSON value. When the body decoded to a
non-object (array/string/number/null), body['evidence'] raised a raw
TypeError before the guarded construction block, escaping the CLI's
VerifierExceptions handler as an uncaught traceback. Add an
isinstance(body, dict) guard right after decode, raising
AssertionFormatIncorrect.

VERIFIED: pytest -q (401 passed), flake8, mypy all clean; reproduced the
raw TypeError before the fix and confirmed AssertionFormatIncorrect for
list/str/int/null/bool bodies after.

Fixes #89
