### PR TITLE
docs: fix stale FileExistsError claims for init/publish

### DIFF
--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -82,6 +82,15 @@ def test_version_is_single_sourced():
     assert not re.search(r'(?m)^version\s*=\s*"', pyproject)
 
 
+def test_cli_reference_does_not_claim_fileexistserror():
+    """openbadges-init/publish exit cleanly with a '[!] ... already exists'
+    message on a pre-existing target; the wiki must not still claim they raise
+    a raw FileExistsError."""
+    doc = (WIKI / 'CLI-Reference.md').read_text(encoding='utf-8')
+    assert 'FileExistsError' not in doc, \
+        "CLI-Reference.md still claims a FileExistsError; init/publish exit cleanly instead"
+
+
 @pytest.mark.parametrize('name', CLI_TOOLS)
 def test_build_parser_is_exposed(name):
     """Each CLI tool exposes build_parser() so the parser is testable/documentable."""

--- a/wiki/CLI-Reference.md
+++ b/wiki/CLI-Reference.md
@@ -27,7 +27,7 @@ $ ls myissuer
 config.ini  images  keys  log
 ```
 
-If the directory already exists the script raises `FileExistsError`. Edit the generated `config.ini` before running any other command — see [[Configuration]].
+If the target path already exists the script prints `[!] <path> already exists` and exits with a non-zero status. Edit the generated `config.ini` before running any other command — see [[Configuration]].
 
 ## openbadges-keygenerator
 
@@ -200,4 +200,4 @@ $ openbadges-publish -o ./public -V 3
 [i] Recipients verify credentials offline using the issuer's public key.
 ```
 
-If the output directory already exists, the OB2 path raises `FileExistsError`.
+If the output directory already exists, the OB2 path prints `[!] <path> already exists` and exits with a non-zero status.


### PR DESCRIPTION
openbadges-init and openbadges-publish now print '[!] <path> already
exists' and exit non-zero on a pre-existing target (issue #83), but
CLI-Reference.md still described the old raw FileExistsError. Update
both sentences and add a test_docs.py gate so the claim can't drift back.

VERIFIED: pytest tests/test_docs.py -q (9 passed); flake8 clean.

Fixes #90
