### PR TITLE
security(ob2): honor revocation with a falsy reason

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,6 +6,11 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
 
 * Unreleased
 
+  - SECURITY: OB2 revocation is now honored even when the issuer publishes an
+    empty/falsy reason for a revoked serial. Previously a revoked badge whose
+    revocation-list reason was "", null, false, or 0 was reported VALID
+    instead of REVOKED (the revocation control failed open for those entries).
+
   - fix: BadgeSigned.read_from_file() now raises AssertionFormatIncorrect
     instead of a raw TypeError/AttributeError when the JWS body decodes to a
     valid-JSON non-object (array, string, number, or null).

--- a/openbadgeslib/ob2/verifier.py
+++ b/openbadgeslib/ob2/verifier.py
@@ -179,7 +179,12 @@ class Verifier():
         if revocation:
             for badge_id in revocation:
                 if str(badge_id) == serial_num:
-                    return revocation[badge_id]
+                    # A matched serial means the badge IS revoked, regardless of
+                    # whether the issuer published a (possibly empty/falsy)
+                    # reason. Always return a truthy string so the presence of a
+                    # revocation is never masked by a falsy reason value.
+                    reason = revocation[badge_id]
+                    return str(reason) if reason else 'Revoked (no reason provided)'
 
         return None
 

--- a/tests/test_verify_operation.py
+++ b/tests/test_verify_operation.py
@@ -225,6 +225,35 @@ class TestCheckRevocation:
                    side_effect=self._fake_download(badge, badge_json, issuer_json, revocation_json)):
             assert v.check_revocation(badge) == 'Mistake'
 
+    @pytest.mark.parametrize('reason', ['', None, False, 0])
+    def test_revoked_serial_with_falsy_reason_still_reports_revoked(self, badge_for_verify_rsa, reason):
+        # A matched serial means REVOKED even when the issuer published a falsy
+        # reason — check_revocation must return a truthy value so the presence
+        # of the revocation is not masked.
+        badge, identity = badge_for_verify_rsa
+        v = Verifier(identity=identity)
+        badge_json = {'issuer': 'https://example.com/issuer.json'}
+        issuer_json = {'revocationList': 'https://example.com/revoked.json'}
+        revocation_json = {str(badge.serial_num): reason}
+        with patch('openbadgeslib.ob2.verifier.download_file',
+                   side_effect=self._fake_download(badge, badge_json, issuer_json, revocation_json)):
+            result = v.check_revocation(badge)
+        assert result  # truthy
+
+    @pytest.mark.parametrize('reason', ['', None, False, 0])
+    def test_get_badge_status_revoked_with_falsy_reason(self, badge_for_verify_rsa, reason):
+        # End-to-end: a revoked badge with a falsy reason must be reported
+        # REVOKED, not VALID (the truthiness-gating bug).
+        badge, identity = badge_for_verify_rsa
+        v = Verifier(identity=identity)
+        badge_json = {'issuer': 'https://example.com/issuer.json'}
+        issuer_json = {'revocationList': 'https://example.com/revoked.json'}
+        revocation_json = {str(badge.serial_num): reason}
+        with patch('openbadgeslib.ob2.verifier.download_file',
+                   side_effect=self._fake_download(badge, badge_json, issuer_json, revocation_json)):
+            result = v.get_badge_status(badge)
+        assert result.status is BadgeStatus.REVOKED
+
     def test_not_revoked_returns_none(self, badge_for_verify_rsa):
         badge, identity = badge_for_verify_rsa
         v = Verifier(identity=identity)


### PR DESCRIPTION
get_badge_status() gated the REVOKED branch on `if reason:`, where reason
was check_revocation()'s raw return value. When the issuer published a
falsy reason ("", null, false, 0) for a revoked serial, the matched
badge was reported VALID instead of REVOKED — the revocation control
failed open. check_revocation() now returns a truthy string on any serial
match (falling back to 'Revoked (no reason provided)'), so presence of a
revocation is never masked by a falsy reason.

VERIFIED: pytest -q (410 passed), flake8, mypy all clean; the 8 new
regression tests fail on master (badge reported VALID) and pass with the
fix (REVOKED). Only strengthens the control; a matched serial is the
revocation signal, non-matches still return None.

Fixes #93
