### PR TITLE
fix(jws): reject a non-string alg header cleanly

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -11,6 +11,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     revocation-list reason was "", null, false, or 0 was reported VALID
     instead of REVOKED (the revocation control failed open for those entries).
 
+  - fix: _jws.verify_block() now rejects a non-string JWS header 'alg' (e.g. a
+    JSON array/object) with a clean JWSException instead of leaking a raw
+    TypeError from the algorithm-allowlist membership test.
+
   - fix: BadgeSigned.read_from_file() now raises AssertionFormatIncorrect
     instead of a raw TypeError/AttributeError when the JWS body decodes to a
     valid-JSON non-object (array, string, number, or null).

--- a/openbadgeslib/_jws/__init__.py
+++ b/openbadgeslib/_jws/__init__.py
@@ -85,8 +85,11 @@ def verify_block(msg: Union[str, bytes], key: Optional[Any] = None) -> bool:
         raise SignatureError("Malformed JWS header")
 
     alg_name = header.get('alg')
-    if not alg_name:
-        raise MissingVerifier("JWS header is missing 'alg'")
+    if not isinstance(alg_name, str) or not alg_name:
+        # A non-string 'alg' (JSON array/object) is truthy but unhashable, so
+        # it would raise a raw TypeError at the `not in allowed` membership
+        # test below. Reject any non-string/empty alg here as a clean JWSException.
+        raise MissingVerifier("JWS header 'alg' is missing or not a string")
 
     allowed = _allowed_algs_for_key(key)
     if allowed and alg_name not in allowed:

--- a/tests/test_jws.py
+++ b/tests/test_jws.py
@@ -169,6 +169,17 @@ class TestVerifyBlockEdgeCases:
         with pytest.raises(SignatureError):
             verify_block(jws, key=k.get_pub_key())
 
+    @pytest.mark.parametrize('bad_alg', [['ES256'], {'a': 1}, 123, True])
+    def test_non_string_alg_header_raises_jws_exception(self, rsa_pub_pem, bad_alg):
+        """A non-string 'alg' (esp. an unhashable list/dict) must be rejected as
+        a clean JWSException, not leak a raw TypeError from the membership test."""
+        from openbadgeslib.keys import KeyRSA
+        k = KeyRSA()
+        k.read_public_key(rsa_pub_pem)
+        jws = utils.encode({'alg': bad_alg}) + b'.' + utils.encode(PAYLOAD) + b'.' + utils.to_base64(b'sig')
+        with pytest.raises(MissingVerifier):
+            verify_block(jws, key=k.get_pub_key())
+
 
 class TestExceptionHierarchy:
     def test_all_jws_exceptions_are_libopenbadgesexception(self):


### PR DESCRIPTION
verify_block() guarded 'alg' only with `if not alg_name`, so a truthy
but non-string value (a JSON array/object from an attacker-controlled
badge header) passed through to `alg_name not in allowed` and raised a
raw TypeError (unhashable type) that escaped the JWSException contract.
Require isinstance(alg_name, str) up front.

VERIFIED: pytest -q (414 passed), flake8, mypy all clean; reproduced the
raw TypeError for list/dict alg before the fix and confirmed a clean
MissingVerifier (JWSException) after.

Fixes #94
