### PR TITLE
fix(verifier): present any library error cleanly on the OB2 CLI

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -15,6 +15,10 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     JSON array/object) with a clean JWSException instead of leaking a raw
     TypeError from the algorithm-allowlist membership test.
 
+  - fix: openbadges-verifier's OB2 path now reports a clean error instead of an
+    uncaught traceback for an unsupported file extension (and any other library
+    exception), by catching LibOpenBadgesException at the CLI boundary.
+
   - fix: BadgeSigned.read_from_file() now raises AssertionFormatIncorrect
     instead of a raw TypeError/AttributeError when the JWS body decodes to a
     valid-JSON non-object (array, string, number, or null).

--- a/openbadgeslib/openbadges_verifier.py
+++ b/openbadgeslib/openbadges_verifier.py
@@ -36,7 +36,7 @@ import os
 
 from typing import Optional
 
-from .errors import VerifierExceptions
+from .errors import LibOpenBadgesException
 from .confparser import read_config_or_exit, resolve_badge_section
 from .logs import enable_debug_logging
 from .ob2 import Verifier, BadgeSigned, BadgeStatus
@@ -151,7 +151,11 @@ def _verify_ob2(args: argparse.Namespace) -> None:
         else:
             print('[-] ', check.msg)
 
-    except VerifierExceptions as exc:
+    except LibOpenBadgesException as exc:
+        # Present any library exception (unsupported image format, malformed
+        # assertion, unreadable key material, …) as a clean CLI error rather
+        # than an uncaught traceback. BadgeImgFormatUnsupported and the key-read
+        # errors inherit LibOpenBadgesException but not VerifierExceptions.
         print('[-] %s' % exc)
         sys.exit(-1)
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -221,6 +221,22 @@ def test_verifier_missing_file_exits(tmp_path):
             openbadges_verifier.main()
 
 
+def test_verifier_ob2_unsupported_extension_exits_cleanly(tmp_path, capsys):
+    # An OB2 badge file whose extension is neither .svg nor .png makes
+    # read_from_file raise BadgeImgFormatUnsupported (a LibOpenBadgesException,
+    # not a VerifierExceptions). The CLI must report it cleanly, not crash.
+    import pytest
+    from openbadgeslib import openbadges_verifier
+    badge_file = tmp_path / 'badge.jpg'
+    badge_file.write_bytes(b'not really an image')
+    argv = ['openbadges-verifier', '-i', str(badge_file),
+            '-r', 'recipient@example.com', '-V', '2']
+    with patch.object(sys, 'argv', argv):
+        with pytest.raises(SystemExit):
+            openbadges_verifier.main()
+    assert '[-]' in capsys.readouterr().out
+
+
 def test_verifier_local_missing_pubkey_file_exits_cleanly(tmp_path):
     # The --local branch of _resolve_trusted_pubkey must guard a missing
     # public_key path the same way the --pubkey branch already does, instead


### PR DESCRIPTION
_verify_ob2 caught only VerifierExceptions, so BadgeImgFormatUnsupported
(raised by read_from_file for a non-.svg/.png file) and the key-read
errors — which inherit LibOpenBadgesException but not VerifierExceptions
— escaped as an uncaught traceback. Catch LibOpenBadgesException at the
CLI boundary so every library exception becomes a clean '[-] ...' exit.

VERIFIED: pytest -q (415 passed), flake8, mypy all clean; reproduced the
raw BadgeImgFormatUnsupported traceback before the fix and confirmed a
clean '[-]' exit after.

Fixes #95
