### PR TITLE
fix(ob2): accept a key object in Verifier construction guard

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,6 +6,11 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
 
 * Unreleased
 
+  - fix: OB2 Verifier(verify_key=...) again accepts a live pycryptodome/ecdsa
+    key object (not only PEM bytes); the construction-time key-type guard now
+    wraps the key in key_to_pem() first, matching the verification path and
+    OB3Verifier.
+
   - SECURITY: OB2 revocation is now honored even when the issuer publishes an
     empty/falsy reason for a revoked serial. Previously a revoked badge whose
     revocation-list reason was "", null, false, or 0 was reported VALID

--- a/openbadgeslib/ob2/verifier.py
+++ b/openbadgeslib/ob2/verifier.py
@@ -25,7 +25,7 @@ from typing import Any, Optional
 
 from .badge import BadgeStatus
 from ..util import hash_email, download_file, show_ecc_disclaimer
-from ..keys import KeyType, detect_key_type
+from ..keys import KeyType, detect_key_type, key_to_pem
 from .._jws.exceptions import JWSException
 from .._jws import verify_block as jws_verify_block
 from .._jws import utils as jws_utils
@@ -54,8 +54,11 @@ class Verifier():
             # (_allowed_algs_for_key) re-derives the key type itself from the
             # key it verifies against. This call exists only to reject an
             # unrecognizable verify_key early, with a clean exception.
+            # Wrap in key_to_pem() so a live RSA/ecdsa key object — which the
+            # verification path already accepts — is not rejected here, mirroring
+            # OB3Verifier.__init__.
             try:
-                detect_key_type(self.verify_key)
+                detect_key_type(key_to_pem(self.verify_key))
             except UnknownKeyType as exc:
                 raise VerifierExceptions(str(exc)) from exc
 

--- a/tests/test_verify_operation.py
+++ b/tests/test_verify_operation.py
@@ -393,6 +393,33 @@ class TestVerifierConstructorKeyTypeValidation:
             Verifier(verify_key=b'this is not a pem key at all, just garbage text',
                      identity='foo@example.com')
 
+    def test_rsa_key_object_is_accepted(self, rsa_pub_pem):
+        # A live RSA key object (not PEM bytes) must be accepted at
+        # construction — the verification path goes through key_to_pem(), so
+        # the constructor guard must too.
+        from openbadgeslib.keys import KeyRSA
+        k = KeyRSA()
+        k.read_public_key(rsa_pub_pem)
+        v = Verifier(verify_key=k.get_pub_key(), identity='foo@example.com')
+        assert v.verify_key is not None
+
+    def test_ecc_key_object_is_accepted(self, ecc_pub_pem):
+        from openbadgeslib.keys import KeyECC
+        k = KeyECC()
+        k.read_public_key(ecc_pub_pem)
+        v = Verifier(verify_key=k.get_pub_key(), identity='foo@example.com')
+        assert v.verify_key is not None
+
+    def test_key_object_verifies_badge(self, badge_for_verify_rsa, rsa_pub_pem):
+        # End-to-end: a key object accepted at construction must actually work
+        # for verification.
+        from openbadgeslib.keys import KeyRSA
+        badge, identity = badge_for_verify_rsa
+        k = KeyRSA()
+        k.read_public_key(rsa_pub_pem)
+        v = Verifier(verify_key=k.get_pub_key(), identity=identity)
+        assert v.check_jws_signature(badge).status is BadgeStatus.VALID
+
 
 class TestEmbeddedKeyFallback:
     """The verify_key=None path trusts the key embedded in the badge itself —


### PR DESCRIPTION
The round-2 construction-time key-type guard called
detect_key_type(self.verify_key) directly, but detect_key_type only
accepts PEM bytes/str — so a live RSA/ecdsa key object (which the
verification path accepts, since it routes through key_to_pem) was
wrongly rejected at construction with VerifierExceptions. Wrap the guard
argument in key_to_pem(), mirroring OB3Verifier.__init__.

VERIFIED: pytest -q (418 passed), flake8, mypy all clean; reproduced the
spurious VerifierExceptions for an RSA/ecdsa key object before the fix
and confirmed acceptance + successful verification after.

Fixes #99
