### PR TITLE
fix(confparser): present a malformed config cleanly at the CLI

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -11,6 +11,11 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     wraps the key in key_to_pem() first, matching the verification path and
     OB3Verifier.
 
+  - fix: a malformed config.ini (bad INI syntax, an unresolvable ${...}
+    reference, an encoding mismatch, or a missing/empty [paths] base) now makes
+    every CLI exit cleanly with a '[!] ...' message instead of a raw traceback;
+    read_config_or_exit() catches the typed ValueError from read_conf().
+
   - SECURITY: OB2 revocation is now honored even when the issuer publishes an
     empty/falsy reason for a revoked serial. Previously a revoked badge whose
     revocation-list reason was "", null, false, or 0 was reported VALID

--- a/openbadgeslib/confparser.py
+++ b/openbadgeslib/confparser.py
@@ -31,8 +31,16 @@ logger = logging.getLogger(__name__)
 
 def read_config_or_exit(config_file: str) -> ConfigParser:
     """Read a config file for a CLI tool, exiting with a clear message if it is
-    missing or empty. Shared by all the console-script entrypoints."""
-    conf = ConfParser(config_file).read_conf()
+    missing, empty, or malformed. Shared by all the console-script entrypoints."""
+    try:
+        conf = ConfParser(config_file).read_conf()
+    except ValueError as exc:
+        # read_conf() raises a clean, typed ValueError for a malformed config
+        # (bad INI syntax, an unresolvable ${...} reference, an encoding
+        # mismatch, or a missing/empty [paths] base). Present it as a controlled
+        # CLI error rather than letting it escape as a raw traceback.
+        print('[!] %s' % exc)
+        sys.exit(-1)
     if not conf:
         print('[!] The config file %s does not exist or is empty' % config_file)
         sys.exit(-1)

--- a/tests/test_confparser.py
+++ b/tests/test_confparser.py
@@ -68,3 +68,30 @@ class TestReadConfBaseValidation:
         path = _write(tmp_path, 'base = .\n\n[paths]\nbase = .\n')
         with pytest.raises(ValueError):
             ConfParser(path).read_conf()
+
+
+class TestReadConfigOrExit:
+    """read_config_or_exit() is the shared CLI wrapper; a malformed config must
+    exit cleanly (SystemExit + '[!] ...'), not leak read_conf()'s ValueError."""
+
+    def test_unresolvable_interpolation_exits_cleanly(self, tmp_path, capsys):
+        from openbadgeslib.confparser import read_config_or_exit
+        path = _write(
+            tmp_path,
+            '[paths]\nbase = .\n\n[issuer]\nname = ${nonexistent:key}\n')
+        with pytest.raises(SystemExit):
+            read_config_or_exit(path)
+        assert capsys.readouterr().out.startswith('[!]')
+
+    def test_invalid_ini_syntax_exits_cleanly(self, tmp_path, capsys):
+        from openbadgeslib.confparser import read_config_or_exit
+        path = _write(tmp_path, '[paths]\nbase = .\nbase = ./other\n')  # duplicate option
+        with pytest.raises(SystemExit):
+            read_config_or_exit(path)
+        assert capsys.readouterr().out.startswith('[!]')
+
+    def test_missing_file_exits_cleanly(self, tmp_path, capsys):
+        from openbadgeslib.confparser import read_config_or_exit
+        with pytest.raises(SystemExit):
+            read_config_or_exit(str(tmp_path / 'missing.ini'))
+        assert 'does not exist or is empty' in capsys.readouterr().out


### PR DESCRIPTION
read_conf() was hardened to raise a typed ValueError for a malformed
config, but the shared read_config_or_exit() wrapper only handled the
missing/empty case — the ValueError escaped uncaught through all five
console entrypoints as a raw traceback. Catch it in the wrapper and
exit(-1) with a '[!] ...' message, fixing every CLI in one place.

VERIFIED: pytest -q (421 passed), flake8, mypy all clean; reproduced the
uncaught ValueError before the fix and confirmed a clean SystemExit +
'[!]' message after for bad interpolation and invalid INI syntax.

Fixes #100
