### PR TITLE
feat(keys): add Ed25519 (EdDSA) key support across OB2 and OB3

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -4,6 +4,17 @@ OpenBadgesLib - Changelog
 Newest first. Dates are ISO 8601 (YYYY-MM-DD).
 
 
+* Unreleased
+
+  - feat: Ed25519 (EdDSA) keys are now supported end to end — key generation
+    (set key_type = ED25519 in the badge profile), plus OB2 JWS and OB3 JWT-VC
+    signing and verification. detect_key_type classifies an Ed25519 PEM
+    explicitly (the ecdsa library would otherwise misread it as an ECC/NIST
+    key), and the algorithm-pinning allowlists bind EdDSA to Ed25519 keys, so
+    cross-type tokens are still rejected. cryptography is now an explicit
+    dependency (it was already pulled in transitively by PyJWT[crypto]).
+
+
 * v1.1.6 - 2026-07-01
 
   - fix: OB2 Verifier(verify_key=...) again accepts a live pycryptodome/ecdsa

--- a/openbadgeslib/_jws/__init__.py
+++ b/openbadgeslib/_jws/__init__.py
@@ -5,12 +5,14 @@ from typing import Any, Dict, Optional, Set, Union
 from . import utils
 from .exceptions import SignatureError, MissingKey, MissingSigner, MissingVerifier, RouteMissingError
 
-from jwt.algorithms import RSAAlgorithm, ECAlgorithm
+from jwt.algorithms import RSAAlgorithm, ECAlgorithm, OKPAlgorithm
 from jwt.exceptions import InvalidKeyError
 
 from ..keys import KeyType, detect_key_type, key_to_pem
 from ..errors import UnknownKeyType
 
+# Each entry is (algorithm class, hash id). EdDSA's OKPAlgorithm takes no hash
+# argument — its hash id is None and _algo_for constructs it with no args.
 _ALGORITHMS = {
     'RS256': (RSAAlgorithm, RSAAlgorithm.SHA256),
     'RS384': (RSAAlgorithm, RSAAlgorithm.SHA384),
@@ -18,6 +20,7 @@ _ALGORITHMS = {
     'ES256': (ECAlgorithm,  ECAlgorithm.SHA256),
     'ES384': (ECAlgorithm,  ECAlgorithm.SHA384),
     'ES512': (ECAlgorithm,  ECAlgorithm.SHA512),
+    'EdDSA': (OKPAlgorithm,  None),
 }
 
 
@@ -26,6 +29,8 @@ def _algo_for(alg_name: str) -> Any:
     if entry is None:
         raise RouteMissingError(f"Algorithm {alg_name!r} is not supported")
     cls, hash_id = entry
+    if hash_id is None:
+        return cls()
     return cls(hash_id)
 
 
@@ -44,6 +49,8 @@ def _allowed_algs_for_key(key: Any) -> Set[str]:
         return {'RS256', 'RS384', 'RS512'}
     if key_type is KeyType.ECC:
         return {'ES256', 'ES384', 'ES512'}
+    if key_type is KeyType.ED25519:
+        return {'EdDSA'}
     return set()
 
 

--- a/openbadgeslib/keys.py
+++ b/openbadgeslib/keys.py
@@ -25,6 +25,9 @@ from typing import Any, Optional, Tuple, Union
 from .errors import UnknownKeyType
 from ecdsa import SigningKey, VerifyingKey, NIST256p
 from Crypto.PublicKey import RSA
+from cryptography.hazmat.primitives import serialization as _crypto_serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey, Ed25519PublicKey)
 from enum import Enum
 import logging
 logger = logging.getLogger(__name__)
@@ -33,15 +36,18 @@ logger = logging.getLogger(__name__)
 class KeyType(Enum):
     RSA = 'RSA 2048'
     ECC = 'ECC NIST256p'
+    ED25519 = 'Ed25519'
 
 
-def KeyFactory(key_type: 'KeyType' = KeyType.RSA) -> 'Union[KeyRSA, KeyECC]':
+def KeyFactory(key_type: 'KeyType' = KeyType.RSA) -> 'Union[KeyRSA, KeyECC, KeyEd25519]':
     """ Key Factory Object, Return a Given object type passing a name
         to the constructor. """
     if key_type == KeyType.ECC:
         return KeyECC()
     if key_type == KeyType.RSA:
         return KeyRSA()
+    if key_type == KeyType.ED25519:
+        return KeyEd25519()
     else:
         raise UnknownKeyType()
 
@@ -126,12 +132,70 @@ class KeyECC(KeyBase):
         return self.pub_key.to_pem()
 
 
+def _pem_bytes(key_pem: Union[str, bytes]) -> bytes:
+    return key_pem.encode('utf-8') if isinstance(key_pem, str) else key_pem
+
+
+def _load_ed25519_private_key(key_pem: Optional[Union[str, bytes]]) -> Ed25519PrivateKey:
+    if key_pem is None:
+        raise UnknownKeyType('No Ed25519 private key PEM provided')
+    key = _crypto_serialization.load_pem_private_key(_pem_bytes(key_pem), password=None)
+    if not isinstance(key, Ed25519PrivateKey):
+        raise UnknownKeyType('PEM is not an Ed25519 private key')
+    return key
+
+
+def _load_ed25519_public_key(key_pem: Optional[Union[str, bytes]]) -> Ed25519PublicKey:
+    if key_pem is None:
+        raise UnknownKeyType('No Ed25519 public key PEM provided')
+    key = _crypto_serialization.load_pem_public_key(_pem_bytes(key_pem))
+    if not isinstance(key, Ed25519PublicKey):
+        raise UnknownKeyType('PEM is not an Ed25519 public key')
+    return key
+
+
+class KeyEd25519(KeyBase):
+    """Edwards-curve Ed25519 (EdDSA) key class, backed by ``cryptography``.
+
+    Kept separate from KeyECC: Ed25519 is an EdDSA curve, not an ECDSA NIST
+    curve. It maps to the JWS ``EdDSA`` algorithm, and the ``ecdsa`` library
+    used for the NIST curves would misread its PEM (see detect_key_type).
+    """
+
+    def generate_keypair(self) -> Tuple[bytes, bytes]:
+        """ Generate an Ed25519 keypair, returning PEM (private, public). """
+        self.priv_key = Ed25519PrivateKey.generate()
+        self.pub_key = self.priv_key.public_key()
+        return self.get_priv_key_pem(), self.get_pub_key_pem()
+
+    def read_private_key(self, key_pem: Optional[Union[str, bytes]] = None) -> None:
+        """ Read the private key from param in PEM format """
+        self.priv_key = _load_ed25519_private_key(key_pem)
+
+    def read_public_key(self, key_pem: Optional[Union[str, bytes]] = None) -> None:
+        """ Read the public key from param in PEM format """
+        self.pub_key = _load_ed25519_public_key(key_pem)
+
+    def get_priv_key_pem(self) -> bytes:
+        return self.priv_key.private_bytes(
+            _crypto_serialization.Encoding.PEM,
+            _crypto_serialization.PrivateFormat.PKCS8,
+            _crypto_serialization.NoEncryption())
+
+    def get_pub_key_pem(self) -> bytes:
+        return self.pub_key.public_bytes(
+            _crypto_serialization.Encoding.PEM,
+            _crypto_serialization.PublicFormat.SubjectPublicKeyInfo)
+
+
 def alg_for_key_type(key_type: 'KeyType') -> str:
     """Return the JWS algorithm the library signs with for a given key type."""
     if key_type is KeyType.RSA:
         return 'RS256'
     if key_type is KeyType.ECC:
         return 'ES256'
+    if key_type is KeyType.ED25519:
+        return 'EdDSA'
     raise UnknownKeyType('No signing algorithm for key type: %r' % (key_type,))
 
 
@@ -146,13 +210,50 @@ def key_to_pem(key: Any) -> Union[str, bytes]:
         return key.export_key('PEM')
     if isinstance(key, (SigningKey, VerifyingKey)):
         return key.to_pem()
+    if isinstance(key, Ed25519PrivateKey):
+        return key.private_bytes(
+            _crypto_serialization.Encoding.PEM,
+            _crypto_serialization.PrivateFormat.PKCS8,
+            _crypto_serialization.NoEncryption())
+    if isinstance(key, Ed25519PublicKey):
+        return key.public_bytes(
+            _crypto_serialization.Encoding.PEM,
+            _crypto_serialization.PublicFormat.SubjectPublicKeyInfo)
     if isinstance(key, (bytes, str)):
         return key
     raise UnknownKeyType('Unsupported key object type: %r' % type(key))
 
 
+def _is_ed25519_pem(pem_data: Union[str, bytes]) -> bool:
+    """True if pem_data is an Ed25519 public or private key.
+
+    Probed before the RSA/ECC checks in detect_key_type: the ``ecdsa`` library's
+    VerifyingKey/SigningKey.from_pem *accept* an Ed25519 PEM and would otherwise
+    misclassify it as KeyType.ECC, pinning the wrong (ES*) algorithm family.
+    ``cryptography``'s loaders are unambiguous about the key type.
+    """
+    data = _pem_bytes(pem_data)
+    try:
+        if isinstance(_crypto_serialization.load_pem_public_key(data), Ed25519PublicKey):
+            return True
+    except Exception:
+        pass
+    try:
+        if isinstance(_crypto_serialization.load_pem_private_key(data, password=None),
+                      Ed25519PrivateKey):
+            return True
+    except Exception:
+        pass
+    return False
+
+
 def detect_key_type(pem_data: Union[str, bytes]) -> 'KeyType':
     """ Positive Key type detection """
+
+    # Ed25519 first: see _is_ed25519_pem — the ecdsa library would otherwise
+    # claim an Ed25519 PEM as ECC below.
+    if _is_ed25519_pem(pem_data):
+        return KeyType.ED25519
 
     try:
         RSA.import_key(pem_data)

--- a/openbadgeslib/ob3/credential.py
+++ b/openbadgeslib/ob3/credential.py
@@ -30,7 +30,7 @@ OB3_CONTEXT = [
     "https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json",
 ]
 
-_SUPPORTED_ALGORITHMS = {'RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512'}
+_SUPPORTED_ALGORITHMS = {'RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512', 'EdDSA'}
 
 
 def _iso(dt: datetime) -> str:

--- a/openbadgeslib/ob3/signer.py
+++ b/openbadgeslib/ob3/signer.py
@@ -36,10 +36,11 @@ class OB3Signer:
 
     Args:
         privkey_pem: PEM-encoded private key (bytes, str, or a pycryptodome /
-                     ecdsa key object).  RSA keys produce RS256 tokens;
-                     EC keys produce ES256 tokens.
+                     ecdsa / cryptography key object).  RSA keys produce RS256
+                     tokens; EC keys produce ES256; Ed25519 keys produce EdDSA
+                     (pass ``algorithm='EdDSA'``).
         algorithm:   JWS algorithm identifier.  Defaults to 'RS256'.
-                     Supported: RS256/384/512, ES256/384/512.
+                     Supported: RS256/384/512, ES256/384/512, EdDSA.
     """
 
     def __init__(self, privkey_pem: Any, algorithm: str = 'RS256') -> None:

--- a/openbadgeslib/ob3/verifier.py
+++ b/openbadgeslib/ob3/verifier.py
@@ -39,6 +39,7 @@ from .. import baking
 _ALGORITHMS_BY_KEY_TYPE = {
     KeyType.RSA: ['RS256', 'RS384', 'RS512'],
     KeyType.ECC: ['ES256', 'ES384', 'ES512'],
+    KeyType.ED25519: ['EdDSA'],
 }
 
 

--- a/openbadgeslib/openbadges_keygenerator.py
+++ b/openbadgeslib/openbadges_keygenerator.py
@@ -56,8 +56,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument('-g', '--genkey', metavar='BADGE',
                         help=("Generate a new key pair for the badge section "
                               "[badge_<BADGE>] (the suffix after 'badge_'). "
-                              "Key type (RSA/ECC) is taken from the badge's "
-                              "key_type field; default RSA."))
+                              "Key type (RSA/ECC/ED25519) is taken from the "
+                              "badge's key_type field; default RSA."))
     parser.add_argument('-V', '--ob-version', choices=['2', '3'], default='2',
                         metavar='VERSION',
                         help='OpenBadges specification version to use: 2 (default) or 3. '
@@ -89,8 +89,10 @@ def main() -> None:
         key_type = KeyType.ECC
     elif key_type_name == 'RSA':
         key_type = KeyType.RSA
+    elif key_type_name in ('ED25519', 'EDDSA'):
+        key_type = KeyType.ED25519
     else:
-        sys.exit("Unknown key_type %r for badge '%s' (use RSA or ECC)"
+        sys.exit("Unknown key_type %r for badge '%s' (use RSA, ECC, or ED25519)"
                  % (key_type_name, args.genkey))
 
     for i in (private_key, public_key):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "ecdsa>=0.19",
     "pypng>=0.20220715.0",
     "PyJWT[crypto]>=2.8",
+    "cryptography>=42",
     "defusedxml>=0.7",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,24 @@ def ecc_pub_pem():
     return (TESTS_DIR / 'test_verify_ecc.pem').read_bytes()
 
 
+@pytest.fixture(scope='session')
+def ed25519_keypair():
+    # Generated in-session (not a committed key file) so the suite ships no
+    # private key material on disk.
+    from openbadgeslib.keys import KeyEd25519
+    return KeyEd25519().generate_keypair()  # (priv_pem, pub_pem)
+
+
+@pytest.fixture(scope='session')
+def ed25519_priv_pem(ed25519_keypair):
+    return ed25519_keypair[0]
+
+
+@pytest.fixture(scope='session')
+def ed25519_pub_pem(ed25519_keypair):
+    return ed25519_keypair[1]
+
+
 # ── raw image bytes ────────────────────────────────────────────────────────────
 
 @pytest.fixture(scope='session')
@@ -214,3 +232,15 @@ def ob3_rsa_verifier(rsa_pub_pem):
 def ob3_ecc_verifier(ecc_pub_pem):
     from openbadgeslib.ob3 import OB3Verifier
     return OB3Verifier(pubkey_pem=ecc_pub_pem)
+
+
+@pytest.fixture(scope='session')
+def ob3_ed25519_signer(ed25519_priv_pem):
+    from openbadgeslib.ob3 import OB3Signer
+    return OB3Signer(privkey_pem=ed25519_priv_pem, algorithm='EdDSA')
+
+
+@pytest.fixture(scope='session')
+def ob3_ed25519_verifier(ed25519_pub_pem):
+    from openbadgeslib.ob3 import OB3Verifier
+    return OB3Verifier(pubkey_pem=ed25519_pub_pem)

--- a/tests/test_eddsa.py
+++ b/tests/test_eddsa.py
@@ -1,0 +1,134 @@
+"""Tests for EdDSA / Ed25519 key support (keys, _jws, OB3)."""
+import pytest
+
+from openbadgeslib.keys import (
+    KeyType, KeyFactory, KeyEd25519, alg_for_key_type, key_to_pem, detect_key_type,
+)
+from openbadgeslib._jws import sign, verify_block
+from openbadgeslib._jws import utils
+from openbadgeslib._jws.exceptions import SignatureError
+from openbadgeslib.errors import UnknownKeyType
+
+
+def _build_jws(header, payload, raw_signature):
+    return (
+        utils.encode(header) + b'.'
+        + utils.encode(payload) + b'.'
+        + utils.to_base64(raw_signature)
+    )
+
+
+PAYLOAD = {'uid': 'test-123', 'recipient': {'identity': 'sha256$abc'}}
+
+
+# ── keys ─────────────────────────────────────────────────────────────────────
+
+class TestKeyEd25519:
+    def test_factory_returns_ed25519(self):
+        assert isinstance(KeyFactory(KeyType.ED25519), KeyEd25519)
+
+    def test_generate_returns_pem_pair(self, ed25519_priv_pem, ed25519_pub_pem):
+        assert ed25519_priv_pem.startswith(b'-----BEGIN PRIVATE KEY-----')
+        assert ed25519_pub_pem.startswith(b'-----BEGIN PUBLIC KEY-----')
+
+    def test_read_roundtrip(self, ed25519_priv_pem, ed25519_pub_pem):
+        k = KeyEd25519()
+        k.read_private_key(ed25519_priv_pem)
+        k.read_public_key(ed25519_pub_pem)
+        assert k.get_priv_key_pem() == ed25519_priv_pem
+        assert k.get_pub_key_pem() == ed25519_pub_pem
+
+    def test_alg_for_key_type(self):
+        assert alg_for_key_type(KeyType.ED25519) == 'EdDSA'
+
+    def test_key_to_pem_from_object(self, ed25519_priv_pem, ed25519_pub_pem):
+        k = KeyEd25519()
+        k.read_private_key(ed25519_priv_pem)
+        k.read_public_key(ed25519_pub_pem)
+        assert key_to_pem(k.get_priv_key()) == ed25519_priv_pem
+        assert key_to_pem(k.get_pub_key()) == ed25519_pub_pem
+
+    def test_read_rsa_pem_as_ed25519_rejected(self, rsa_pub_pem):
+        with pytest.raises(UnknownKeyType):
+            KeyEd25519().read_public_key(rsa_pub_pem)
+
+
+class TestDetectKeyType:
+    def test_ed25519_detected_as_ed25519_not_ecc(self, ed25519_pub_pem, ed25519_priv_pem):
+        # Regression: the ecdsa library ACCEPTS an Ed25519 PEM and would
+        # misclassify it as ECC; detection must return ED25519 for both halves.
+        assert detect_key_type(ed25519_pub_pem) is KeyType.ED25519
+        assert detect_key_type(ed25519_priv_pem) is KeyType.ED25519
+
+    def test_ed25519_pem_as_str(self, ed25519_pub_pem):
+        assert detect_key_type(ed25519_pub_pem.decode('ascii')) is KeyType.ED25519
+
+    def test_rsa_still_rsa(self, rsa_pub_pem):
+        assert detect_key_type(rsa_pub_pem) is KeyType.RSA
+
+    def test_ecc_still_ecc(self, ecc_pub_pem):
+        assert detect_key_type(ecc_pub_pem) is KeyType.ECC
+
+
+# ── _jws round-trip + pinning ─────────────────────────────────────────────────
+
+class TestEdDSAJws:
+    def _keys(self, priv_pem, pub_pem):
+        k = KeyEd25519()
+        k.read_private_key(priv_pem)
+        k.read_public_key(pub_pem)
+        return k.get_priv_key(), k.get_pub_key()
+
+    def test_sign_verify_roundtrip(self, ed25519_priv_pem, ed25519_pub_pem):
+        priv, pub = self._keys(ed25519_priv_pem, ed25519_pub_pem)
+        raw_sig = sign({'alg': 'EdDSA'}, PAYLOAD, key=priv)
+        jws = _build_jws({'alg': 'EdDSA'}, PAYLOAD, raw_sig)
+        assert verify_block(jws, key=pub) is True
+
+    def test_tampered_payload_rejected(self, ed25519_priv_pem, ed25519_pub_pem):
+        priv, pub = self._keys(ed25519_priv_pem, ed25519_pub_pem)
+        raw_sig = sign({'alg': 'EdDSA'}, PAYLOAD, key=priv)
+        jws = _build_jws({'alg': 'EdDSA'}, {'uid': 'EVIL'}, raw_sig)
+        with pytest.raises(SignatureError):
+            verify_block(jws, key=pub)
+
+    def test_ed25519_key_rejects_rs256_header(self, ed25519_priv_pem, ed25519_pub_pem):
+        # alg pinning: an Ed25519 verify key must reject a token claiming RS256.
+        _, pub = self._keys(ed25519_priv_pem, ed25519_pub_pem)
+        jws = _build_jws({'alg': 'RS256'}, PAYLOAD, b'sig')
+        with pytest.raises(SignatureError):
+            verify_block(jws, key=pub)
+
+    def test_rsa_key_rejects_eddsa_header(self, rsa_pub_pem):
+        from openbadgeslib.keys import KeyRSA
+        k = KeyRSA()
+        k.read_public_key(rsa_pub_pem)
+        jws = _build_jws({'alg': 'EdDSA'}, PAYLOAD, b'sig')
+        with pytest.raises(SignatureError):
+            verify_block(jws, key=k.get_pub_key())
+
+
+# ── OB3 JWT-VC round-trip ─────────────────────────────────────────────────────
+
+class TestEdDSAOB3:
+    def test_sign_verify_roundtrip(self, ob3_ed25519_signer, ob3_ed25519_verifier, ob3_credential):
+        token = ob3_ed25519_signer.sign(ob3_credential)
+        cred = ob3_ed25519_verifier.verify(token)
+        assert cred.achievement.name == ob3_credential.achievement.name
+
+    def test_token_header_is_eddsa(self, ob3_ed25519_signer, ob3_credential):
+        import jwt
+        token = ob3_ed25519_signer.sign(ob3_credential)
+        assert jwt.get_unverified_header(token)['alg'] == 'EdDSA'
+
+    def test_rsa_verifier_rejects_eddsa_token(self, ob3_ed25519_signer, ob3_rsa_verifier, ob3_credential):
+        from openbadgeslib.ob3 import OB3VerificationError
+        token = ob3_ed25519_signer.sign(ob3_credential)
+        with pytest.raises(OB3VerificationError):
+            ob3_rsa_verifier.verify(token)
+
+    def test_ed25519_verifier_rejects_rsa_token(self, ob3_rsa_signer, ob3_ed25519_verifier, ob3_credential):
+        from openbadgeslib.ob3 import OB3VerificationError
+        token = ob3_rsa_signer.sign(ob3_credential)
+        with pytest.raises(OB3VerificationError):
+            ob3_ed25519_verifier.verify(token)


### PR DESCRIPTION
Add KeyType.ED25519 with a KeyEd25519 factory class (cryptography-backed
generation/PEM I/O), wire EdDSA into the _jws algorithm table and the OB2
and OB3 algorithm-pinning allowlists, and accept key_type = ED25519 in the
keygenerator badge profile.

detect_key_type probes Ed25519 first: the ecdsa library's
VerifyingKey/SigningKey.from_pem accept an Ed25519 PEM and would otherwise
misclassify it as KeyType.ECC, pinning the wrong (ES*) algorithm family.
cross-type tokens (RSA key vs EdDSA token and vice-versa) are still rejected.
cryptography is now an explicit dependency (was transitive via PyJWT[crypto]).

Fixes #103

VERIFIED: flake8, mypy, and pytest (439 passed, +18 new EdDSA tests) all
green; Ed25519 round-trips through OB2 JWS and OB3 JWT-VC sign/verify.
