### PR TITLE
feat(ob3): check credential revocation via credentialStatus

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,6 +6,17 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
 
 * Unreleased
 
+  - SECURITY: OB3 credential revocation is now checkable. OB3Verifier.verify()
+    gained an opt-in check_status=True (and openbadges-verifier a --check-status
+    flag) that resolves each credentialStatus entry — Bitstring Status List v1.0
+    and the legacy StatusList2021 — fetches the status list over HTTPS, and
+    rejects a revoked/suspended credential. Previously OB3 had no revocation
+    control at all (a revoked credential verified as VALID). The check is
+    fail-closed when enabled (an unresolvable/malformed status list is a
+    failure, not a pass) and the GZIP inflate of the bitstring is bounded. It
+    verifies the published status bit only, not the status-list credential's own
+    signature (documented).
+
   - feat: Ed25519 (EdDSA) keys are now supported end to end — key generation
     (set key_type = ED25519 in the badge profile), plus OB2 JWS and OB3 JWT-VC
     signing and verification. detect_key_type classifies an Ed25519 PEM

--- a/openbadgeslib/ob3/__init__.py
+++ b/openbadgeslib/ob3/__init__.py
@@ -23,6 +23,7 @@
 from .credential import Achievement, Issuer, OpenBadgeCredential
 from .signer import OB3Signer
 from .verifier import OB3VerificationError, OB3Verifier
+from .status import check_credential_status
 
 __all__ = [
     'Achievement',
@@ -31,4 +32,5 @@ __all__ = [
     'OB3Signer',
     'OB3Verifier',
     'OB3VerificationError',
+    'check_credential_status',
 ]

--- a/openbadgeslib/ob3/credential.py
+++ b/openbadgeslib/ob3/credential.py
@@ -97,6 +97,10 @@ class OpenBadgeCredential:
     issuance_date: Optional[datetime] = None   # defaults to now (UTC)
     expiration_date: Optional[datetime] = None
     evidence_url: Optional[str] = None
+    # Raw credentialStatus entries (Bitstring Status List / StatusList2021),
+    # normalised to a list of objects. Consumed by ob3.status to check
+    # revocation; empty when the credential carries no status.
+    credential_status: List[dict] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         if self.id is None:
@@ -129,6 +133,10 @@ class OpenBadgeCredential:
             vc["validUntil"] = _iso(self.expiration_date)
         if self.evidence_url:
             vc["evidence"] = [{"id": self.evidence_url, "type": ["Evidence"]}]
+        if self.credential_status:
+            vc["credentialStatus"] = (
+                self.credential_status[0] if len(self.credential_status) == 1
+                else self.credential_status)
         return vc
 
     def to_jwt_payload(self) -> dict:
@@ -201,6 +209,16 @@ class OpenBadgeCredential:
         if isinstance(evidence, list) and evidence and isinstance(evidence[0], dict):
             evidence_url = evidence[0].get("id")
 
+        # credentialStatus may be a single object or an array; keep only object
+        # entries so the status checker can rely on .get() without crashing.
+        status_raw = vc.get("credentialStatus")
+        if isinstance(status_raw, dict):
+            credential_status = [status_raw]
+        elif isinstance(status_raw, list):
+            credential_status = [s for s in status_raw if isinstance(s, dict)]
+        else:
+            credential_status = []
+
         return cls(
             id=_require(vc, "id", "vc"),
             issuer=issuer,
@@ -210,6 +228,7 @@ class OpenBadgeCredential:
             issuance_date=issuance_date,
             expiration_date=expiration_date,
             evidence_url=evidence_url,
+            credential_status=credential_status,
         )
 
 

--- a/openbadgeslib/ob3/status.py
+++ b/openbadgeslib/ob3/status.py
@@ -1,0 +1,176 @@
+"""
+        OpenBadges Library
+
+        Copyright (c) 2014-2026, Luis González Fernández, luisgf@luisgf.es
+        Copyright (c) 2014-2026, Jesús Cea Avión, jcea@jcea.es
+
+        All rights reserved.
+
+        This library is free software; you can redistribute it and/or
+        modify it under the terms of the GNU Lesser General Public
+        License as published by the Free Software Foundation; either
+        version 3.0 of the License, or (at your option) any later version.
+
+        This library is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+        Lesser General Public License for more details.
+
+        You should have received a copy of the GNU Lesser General Public
+        License along with this library.
+"""
+
+# OpenBadges 3.0 credential status (revocation) checking.
+#
+# Implements the W3C Bitstring Status List v1.0 mechanism (and the older
+# StatusList2021 shape) used to express revocation/suspension in the Verifiable
+# Credentials data model. This is the OB3 counterpart of OB2's revocation-list
+# check: without it, an issuer's revocation has no effect on the verdict.
+#
+# Trust note: this checks the *published* status bit only. It does NOT verify
+# the status-list credential's own proof/signature — that is a separate trust
+# chain (often a different key). A caller needing that guarantee must verify
+# the status-list credential independently.
+
+import base64
+import json
+import zlib
+
+from typing import Any, Callable, List, Optional
+
+from .credential import OpenBadgeCredential
+from .verifier import OB3VerificationError
+from ..util import download_file
+
+_SUPPORTED_ENTRY_TYPES = {"BitstringStatusListEntry", "StatusList2021Entry"}
+
+#: Upper bound on a decompressed status-list bitstring. A conformant list is at
+#: least 131072 bits (16 KiB); real lists reach a few hundred KiB. Cap well
+#: above that to stop a crafted gzip bomb from exhausting memory (the list is
+#: attacker-influenced: it is fetched from a URL named in an untrusted VC).
+MAX_STATUS_LIST_BYTES = 5 * 1024 * 1024  # 5 MiB
+
+
+def check_credential_status(
+        credential: OpenBadgeCredential,
+        download: Optional[Callable[[str], bytes]] = None) -> None:
+    """Check every credentialStatus entry, raising OB3VerificationError if the
+    credential is revoked/suspended or if its status cannot be determined.
+
+    Fail-closed: a fetch or parse failure raises rather than silently passing.
+    A credential with no credentialStatus is a no-op. ``download`` defaults to
+    util.download_file (HTTPS-only, size-capped); it is injectable for testing.
+    """
+    fetch = download if download is not None else download_file
+    for entry in credential.credential_status:
+        _check_entry(entry, fetch)
+
+
+def _check_entry(entry: dict, download: Callable[[str], bytes]) -> None:
+    types = set(_as_list(entry.get("type")))
+    if not (types & _SUPPORTED_ENTRY_TYPES):
+        raise OB3VerificationError(
+            "unsupported credentialStatus type: %r" % (entry.get("type"),))
+
+    purpose = entry.get("statusPurpose", "revocation")
+    list_url = entry.get("statusListCredential")
+    if not isinstance(list_url, str) or not list_url:
+        raise OB3VerificationError(
+            "credentialStatus is missing a statusListCredential URL")
+    index = _parse_index(entry.get("statusListIndex"))
+
+    try:
+        raw = download(list_url)
+    except Exception as exc:
+        # HTTPS enforcement / size cap / network errors all fail closed.
+        raise OB3VerificationError(
+            "could not fetch status list %s: %s" % (list_url, exc)) from exc
+
+    try:
+        subject = _status_list_subject(raw)
+        encoded = subject.get("encodedList")
+        if not isinstance(encoded, str) or not encoded:
+            raise OB3VerificationError("status list credential has no encodedList")
+        bitstring = _decode_encoded_list(encoded)
+    except OB3VerificationError:
+        raise
+    except Exception as exc:
+        raise OB3VerificationError(
+            "malformed status list %s: %s" % (list_url, exc)) from exc
+
+    if _bit_set(bitstring, index):
+        raise OB3VerificationError(
+            "Credential status is set (%s) at index %d in %s"
+            % (purpose, index, list_url))
+
+
+def _as_list(value: Any) -> List[Any]:
+    if value is None:
+        return []
+    return value if isinstance(value, list) else [value]
+
+
+def _parse_index(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        raise OB3VerificationError("invalid statusListIndex: %r" % (value,)) from None
+
+
+def _status_list_subject(raw: bytes) -> dict:
+    """Return the credentialSubject of a status-list credential served either as
+    a JSON-LD VC document or as a compact JWT-VC string."""
+    text = raw.decode('utf-8').strip()
+
+    if text.startswith('{'):
+        doc = json.loads(text)
+        # A JWT payload wrapper ({"vc": {...}}) or a bare VC document.
+        if isinstance(doc, dict) and "credentialSubject" not in doc \
+                and isinstance(doc.get("vc"), dict):
+            doc = doc["vc"]
+    elif text.count('.') == 2:                       # compact JWS: h.p.s
+        payload = json.loads(_b64url_decode(text.split('.')[1]))
+        doc = payload.get("vc", payload)
+    else:
+        raise OB3VerificationError("status list is neither JSON nor a JWT")
+
+    if not isinstance(doc, dict):
+        raise OB3VerificationError("status list credential is not an object")
+    subject = doc.get("credentialSubject")
+    if isinstance(subject, list):
+        subject = subject[0] if subject else None
+    if not isinstance(subject, dict):
+        raise OB3VerificationError(
+            "status list credential has no credentialSubject object")
+    return subject
+
+
+def _b64url_decode(value: str) -> bytes:
+    value += '=' * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value)
+
+
+def _decode_encoded_list(encoded: str) -> bytes:
+    """Decode encodedList: optional multibase base64url ('u') prefix, base64url,
+    then a bounded GZIP inflate to the raw bitstring."""
+    if encoded.startswith('u'):          # multibase base64url-no-pad (Bitstring SL)
+        encoded = encoded[1:]
+    compressed = _b64url_decode(encoded)
+    inflator = zlib.decompressobj(wbits=31)   # 31 => gzip framing
+    out = inflator.decompress(compressed, MAX_STATUS_LIST_BYTES)
+    if inflator.unconsumed_tail:
+        raise OB3VerificationError(
+            "status list bitstring exceeds the %d-byte limit" % MAX_STATUS_LIST_BYTES)
+    return out
+
+
+def _bit_set(bitstring: bytes, index: int) -> bool:
+    """Return the bit at *index* in a big-endian (MSB-first) bitstring, matching
+    the Bitstring Status List / StatusList2021 bit ordering."""
+    if index < 0:
+        raise OB3VerificationError("negative statusListIndex %d" % index)
+    byte_index = index // 8
+    if byte_index >= len(bitstring):
+        raise OB3VerificationError(
+            "statusListIndex %d is out of range for the status list" % index)
+    return bool(bitstring[byte_index] & (0x80 >> (index % 8)))

--- a/openbadgeslib/ob3/verifier.py
+++ b/openbadgeslib/ob3/verifier.py
@@ -89,7 +89,8 @@ class OB3Verifier:
     # ── verification ───────────────────────────────────────────────────────────
 
     def verify(self, token: str,
-               expected_recipient: Optional[str] = None) -> OpenBadgeCredential:
+               expected_recipient: Optional[str] = None,
+               check_status: bool = False) -> OpenBadgeCredential:
         """Verify a JWT-VC token.
 
         Returns the decoded :class:`OpenBadgeCredential` on success.
@@ -102,6 +103,12 @@ class OB3Verifier:
         ``mailto:`` URI, or a DID) to additionally require that
         ``credentialSubject.id`` matches; otherwise the caller MUST compare
         ``credential.recipient_id`` itself.
+
+        Pass ``check_status=True`` to also check the credential's
+        ``credentialStatus`` (revocation) — this performs an HTTPS fetch of the
+        referenced status list and fails closed if the credential is revoked or
+        its status cannot be determined. It is off by default because
+        verification is otherwise offline.
         """
         payload = self._decode_payload(token)
         credential = self._build_credential(payload)
@@ -119,6 +126,9 @@ class OB3Verifier:
             raise OB3VerificationError(
                 "Credential is not yet valid (validFrom %s)" % credential.issuance_date.isoformat())
 
+        if check_status:
+            self.check_status(credential)
+
         if expected_recipient is not None:
             expected = normalize_recipient_id(expected_recipient)
             if not recipient_ids_match(credential.recipient_id, expected):
@@ -128,6 +138,18 @@ class OB3Verifier:
                 )
 
         return credential
+
+    def check_status(self, credential: OpenBadgeCredential) -> None:
+        """Check the credential's ``credentialStatus`` (revocation) over the
+        network, raising :class:`OB3VerificationError` if it is revoked/
+        suspended or if the status cannot be determined (fail-closed). A
+        credential carrying no credentialStatus is a no-op.
+
+        Imported lazily so the (network-touching) status module is only pulled
+        in when a caller actually opts into status checking.
+        """
+        from .status import check_credential_status
+        check_credential_status(credential)
 
     def _decode_payload(self, token: str) -> dict:
         """Verify the signature (algorithm pinned to the key type) and return

--- a/openbadgeslib/openbadges_verifier.py
+++ b/openbadgeslib/openbadges_verifier.py
@@ -86,6 +86,9 @@ def build_parser() -> argparse.ArgumentParser:
              'verification (OB2 and OB3)')
     parser.add_argument('-s', '--show', action='store_true',
                         help='Show the assertion/credential of the OpenBadge being verified.')
+    parser.add_argument('--check-status', action='store_true',
+                        help='OB3 only: fetch the credentialStatus list and reject a '
+                             'revoked/suspended credential (requires network access).')
     parser.add_argument('-V', '--ob-version', choices=['2', '3'], default='2',
                         metavar='VERSION',
                         help='OpenBadges specification version: 2 (default, JWS) or 3 (JWT-VC).')
@@ -189,7 +192,8 @@ def _verify_ob3(args: argparse.Namespace) -> None:
     # compares), instead of re-implementing the comparison here.
     try:
         verifier = OB3Verifier(pubkey_pem=pub_pem)
-        credential = verifier.verify(token, expected_recipient=args.receptor)
+        credential = verifier.verify(token, expected_recipient=args.receptor,
+                                     check_status=args.check_status)
     except OB3VerificationError as exc:
         print('[-] OB3 verification failed: %s' % exc)
         sys.exit(-1)

--- a/tests/test_ob3_status.py
+++ b/tests/test_ob3_status.py
@@ -1,0 +1,216 @@
+"""Tests for OB3 credentialStatus (revocation) checking — ob3.status."""
+import base64
+import gzip
+import json
+
+import pytest
+
+from openbadgeslib.ob3 import OB3VerificationError, check_credential_status
+from openbadgeslib.ob3.credential import OpenBadgeCredential
+
+
+LIST_URL = 'https://issuer.example/status/1'
+
+
+def _encoded_list(set_indices, size_bits=131072):
+    """Build a Bitstring Status List `encodedList` (multibase base64url of a
+    GZIP-compressed MSB-first bitstring) with *set_indices* flipped on."""
+    ba = bytearray(size_bits // 8)
+    for i in set_indices:
+        ba[i // 8] |= (0x80 >> (i % 8))
+    gz = gzip.compress(bytes(ba))
+    return 'u' + base64.urlsafe_b64encode(gz).decode('ascii').rstrip('=')
+
+
+def _status_list_doc(set_indices, purpose='revocation'):
+    return {
+        "@context": ["https://www.w3.org/ns/credentials/v2"],
+        "id": LIST_URL,
+        "type": ["VerifiableCredential", "BitstringStatusListCredential"],
+        "credentialSubject": {
+            "id": LIST_URL + "#list",
+            "type": "BitstringStatusList",
+            "statusPurpose": purpose,
+            "encodedList": _encoded_list(set_indices),
+        },
+    }
+
+
+def _status_entry(index, purpose='revocation', type_='BitstringStatusListEntry'):
+    return {
+        "id": "%s#%d" % (LIST_URL, index),
+        "type": type_,
+        "statusPurpose": purpose,
+        "statusListIndex": str(index),
+        "statusListCredential": LIST_URL,
+    }
+
+
+def _credential(entries):
+    from openbadgeslib.ob3 import Achievement, Issuer
+    return OpenBadgeCredential(
+        id='urn:uuid:00000000-0000-0000-0000-0000000000aa',
+        issuer=Issuer(id='https://issuer.example', name='Issuer'),
+        recipient_id='mailto:r@example.com',
+        achievement=Achievement(id='https://issuer.example/a/1', name='A',
+                                description='d', criteria_narrative='c'),
+        credential_status=entries,
+    )
+
+
+def _downloader(doc):
+    payload = json.dumps(doc).encode('utf-8')
+
+    def _dl(url):
+        assert url == LIST_URL
+        return payload
+    return _dl
+
+
+# ── core checker ─────────────────────────────────────────────────────────────
+
+class TestCheckCredentialStatus:
+    def test_no_status_is_noop(self):
+        check_credential_status(_credential([]), download=_downloader({}))
+
+    def test_unrevoked_passes(self):
+        cred = _credential([_status_entry(94)])
+        check_credential_status(cred, download=_downloader(_status_list_doc(set_indices=[7])))
+
+    def test_revoked_bit_rejected(self):
+        cred = _credential([_status_entry(94)])
+        with pytest.raises(OB3VerificationError, match='revocation'):
+            check_credential_status(cred, download=_downloader(_status_list_doc(set_indices=[94])))
+
+    def test_suspension_purpose_reported(self):
+        cred = _credential([_status_entry(3, purpose='suspension')])
+        doc = _status_list_doc(set_indices=[3], purpose='suspension')
+        with pytest.raises(OB3VerificationError, match='suspension'):
+            check_credential_status(cred, download=_downloader(doc))
+
+    def test_legacy_statuslist2021_type_accepted(self):
+        cred = _credential([_status_entry(94, type_='StatusList2021Entry')])
+        with pytest.raises(OB3VerificationError):
+            check_credential_status(cred, download=_downloader(_status_list_doc(set_indices=[94])))
+
+    def test_jwt_vc_status_list_form(self):
+        # Status list served as a compact JWT-VC (header.payload.signature).
+        def _b64(obj):
+            return base64.urlsafe_b64encode(json.dumps(obj).encode()).decode().rstrip('=')
+        doc = _status_list_doc(set_indices=[94])
+        payload = {"iss": "https://issuer.example", "vc": doc}
+        jwt_like = '%s.%s.%s' % (_b64({"alg": "none"}), _b64(payload), 'sig')
+        cred = _credential([_status_entry(94)])
+        with pytest.raises(OB3VerificationError):
+            check_credential_status(cred, download=lambda url: jwt_like.encode('ascii'))
+
+    # ── fail-closed paths ────────────────────────────────────────────────────
+
+    def test_fetch_error_fails_closed(self):
+        def _boom(url):
+            raise ValueError('Refusing to download over insecure scheme')
+        with pytest.raises(OB3VerificationError, match='could not fetch'):
+            check_credential_status(_credential([_status_entry(1)]), download=_boom)
+
+    def test_malformed_list_fails_closed(self):
+        with pytest.raises(OB3VerificationError):
+            check_credential_status(_credential([_status_entry(1)]),
+                                    download=lambda url: b'not json, not jwt')
+
+    def test_missing_encoded_list_fails_closed(self):
+        doc = {"credentialSubject": {"type": "BitstringStatusList"}}
+        with pytest.raises(OB3VerificationError, match='encodedList'):
+            check_credential_status(_credential([_status_entry(1)]), download=_downloader(doc))
+
+    def test_unknown_entry_type_fails_closed(self):
+        cred = _credential([_status_entry(1, type_='SomethingElse')])
+        with pytest.raises(OB3VerificationError, match='unsupported'):
+            check_credential_status(cred, download=_downloader(_status_list_doc([])))
+
+    def test_index_out_of_range_fails_closed(self):
+        cred = _credential([_status_entry(9_999_999)])
+        with pytest.raises(OB3VerificationError, match='out of range'):
+            check_credential_status(cred, download=_downloader(_status_list_doc([])))
+
+    def test_non_numeric_index_fails_closed(self):
+        entry = _status_entry(1)
+        entry['statusListIndex'] = 'not-a-number'
+        with pytest.raises(OB3VerificationError, match='invalid statusListIndex'):
+            check_credential_status(_credential([entry]), download=_downloader(_status_list_doc([])))
+
+
+# ── bit ordering ─────────────────────────────────────────────────────────────
+
+class TestBitOrdering:
+    def test_bit_zero_is_msb_of_first_byte(self):
+        from openbadgeslib.ob3.status import _bit_set
+        assert _bit_set(b'\x80', 0) is True
+        assert _bit_set(b'\x80', 1) is False
+        assert _bit_set(b'\x01', 7) is True
+
+
+# ── model parsing ────────────────────────────────────────────────────────────
+
+class TestCredentialStatusParsing:
+    def _payload(self, status):
+        return {
+            "vc": {
+                "id": "urn:uuid:1",
+                "type": ["VerifiableCredential", "OpenBadgeCredential"],
+                "issuer": {"id": "https://i.example", "name": "I"},
+                "credentialStatus": status,
+                "credentialSubject": {
+                    "id": "mailto:r@example.com",
+                    "achievement": {"id": "https://i.example/a", "name": "A"},
+                },
+            }
+        }
+
+    def test_single_object_normalised_to_list(self):
+        cred = OpenBadgeCredential.from_jwt_payload(self._payload(_status_entry(1)))
+        assert cred.credential_status == [_status_entry(1)]
+
+    def test_array_kept(self):
+        entries = [_status_entry(1), _status_entry(2)]
+        cred = OpenBadgeCredential.from_jwt_payload(self._payload(entries))
+        assert cred.credential_status == entries
+
+    def test_absent_is_empty(self):
+        payload = self._payload(None)
+        del payload['vc']['credentialStatus']
+        cred = OpenBadgeCredential.from_jwt_payload(payload)
+        assert cred.credential_status == []
+
+
+# ── integration through verify(check_status=True) ────────────────────────────
+
+class TestVerifyWithStatus:
+    def _sign(self, signer, entries):
+        return signer.sign(_credential(entries))
+
+    def test_verify_rejects_revoked(self, ob3_rsa_signer, ob3_rsa_verifier, monkeypatch):
+        import openbadgeslib.ob3.status as status_mod
+        monkeypatch.setattr(status_mod, 'download_file',
+                            _downloader(_status_list_doc(set_indices=[94])))
+        token = self._sign(ob3_rsa_signer, [_status_entry(94)])
+        with pytest.raises(OB3VerificationError):
+            ob3_rsa_verifier.verify(token, check_status=True)
+
+    def test_verify_passes_unrevoked(self, ob3_rsa_signer, ob3_rsa_verifier, monkeypatch):
+        import openbadgeslib.ob3.status as status_mod
+        monkeypatch.setattr(status_mod, 'download_file',
+                            _downloader(_status_list_doc(set_indices=[])))
+        token = self._sign(ob3_rsa_signer, [_status_entry(94)])
+        cred = ob3_rsa_verifier.verify(token, check_status=True)
+        assert cred.recipient_id == 'mailto:r@example.com'
+
+    def test_check_status_off_by_default(self, ob3_rsa_signer, ob3_rsa_verifier, monkeypatch):
+        # With check_status=False (default) no network call happens even when a
+        # revoked status is present.
+        import openbadgeslib.ob3.status as status_mod
+
+        def _fail(url):
+            raise AssertionError('network must not be touched when check_status=False')
+        monkeypatch.setattr(status_mod, 'download_file', _fail)
+        token = self._sign(ob3_rsa_signer, [_status_entry(94)])
+        assert ob3_rsa_verifier.verify(token) is not None

--- a/wiki/CLI-Reference.md
+++ b/wiki/CLI-Reference.md
@@ -122,7 +122,7 @@ Extracts the embedded assertion/credential from a signed badge image, checks the
 ### Synopsis
 
 ```sh
-openbadges-verifier -i FILE -r RECEPTOR [-l BADGE | -k FILE] [-c FILE] [-s] [-V {2,3}] [-d]
+openbadges-verifier -i FILE -r RECEPTOR [-l BADGE | -k FILE] [-c FILE] [-s] [--check-status] [-V {2,3}] [-d]
 ```
 
 | Short | Long | Meaning | Default |
@@ -133,9 +133,12 @@ openbadges-verifier -i FILE -r RECEPTOR [-l BADGE | -k FILE] [-c FILE] [-s] [-V 
 | `-l` | `--local BADGE` | Verify against the public key from this badge section in `config.ini` | none |
 | `-k` | `--pubkey FILE` | Verify against this trusted PEM public key file (OB2 and OB3) | none |
 | `-s` | `--show` | Print the assertion/credential before the result | off |
+| | `--check-status` | OB3 only: fetch the `credentialStatus` list and reject a revoked/suspended credential (requires network) | off |
 | `-V` | `--ob-version {2,3}` | `2` = JWS, `3` = JWT-VC | `2` |
 | `-d` | `--debug` | Show debug messages at runtime | off |
 | `-v` | `--version` | Print version and exit | — |
+
+For OB3, `--check-status` resolves each `credentialStatus` entry (W3C Bitstring Status List v1.0 or the legacy StatusList2021), fetches the referenced status list over HTTPS, and rejects the badge if its revocation/suspension bit is set. It is **fail-closed**: an unreachable or malformed status list is treated as a verification failure, not a pass. Only the published status bit is checked, not the status-list credential's own signature. See [[Security Model]].
 
 ### Example (OB2, trusted via local config)
 


### PR DESCRIPTION
Add OB3 credential-status (revocation) checking, the OB3 counterpart of
OB2's revocation-list control. OB3Verifier.verify() gains an opt-in
check_status flag (and openbadges-verifier a --check-status flag) that
resolves each credentialStatus entry — Bitstring Status List v1.0 and the
legacy StatusList2021 — fetches the status list over HTTPS (reusing the
HTTPS-only, size-capped download_file), decodes the multibase base64url +
GZIP bitstring under a bounded inflate, and rejects a set revocation/
suspension bit.

Previously OB3 had no revocation control: a revoked credential verified as
VALID. The check is fail-closed when enabled (an unresolvable or malformed
status list is a failure, not a pass). It verifies the published status bit
only, not the status-list credential's own signature (documented).

Fixes #104

VERIFIED: flake8, mypy, and pytest (458 passed, +19 new status tests incl.
revoked/unrevoked/JWT-VC-list/fail-closed paths and the MSB-first bit order)
all green; CLI-Reference documents --check-status (docs gate passes).
