### PR TITLE
feat(ob3): resolve issuer DIDs (did:key, did:web) to a verify key

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,6 +6,16 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
 
 * Unreleased
 
+  - feat: OB3 issuer DIDs can now be resolved to a verification key. New
+    ob3.resolve_did() and OB3Verifier.for_issuer_did() support did:key (Ed25519
+    and P-256, self-certifying, offline) and did:web (fetches the DID document
+    over HTTPS and reads its first verificationMethod's publicKeyJwk or
+    publicKeyMultibase). openbadges-verifier gained a --resolve-did flag: when
+    no trusted key is supplied for an OB3 badge, the issuer DID is read from the
+    token and resolved, and the signature is checked against the resolved key.
+    did:key needs no external trust; did:web trusts the host's DNS and TLS
+    (documented in the Security Model).
+
   - SECURITY: OB3 credential revocation is now checkable. OB3Verifier.verify()
     gained an opt-in check_status=True (and openbadges-verifier a --check-status
     flag) that resolves each credentialStatus entry — Bitstring Status List v1.0

--- a/openbadgeslib/ob3/__init__.py
+++ b/openbadgeslib/ob3/__init__.py
@@ -24,6 +24,7 @@ from .credential import Achievement, Issuer, OpenBadgeCredential
 from .signer import OB3Signer
 from .verifier import OB3VerificationError, OB3Verifier
 from .status import check_credential_status
+from .did import resolve_did
 
 __all__ = [
     'Achievement',
@@ -33,4 +34,5 @@ __all__ = [
     'OB3Verifier',
     'OB3VerificationError',
     'check_credential_status',
+    'resolve_did',
 ]

--- a/openbadgeslib/ob3/did.py
+++ b/openbadgeslib/ob3/did.py
@@ -1,0 +1,194 @@
+"""
+        OpenBadges Library
+
+        Copyright (c) 2014-2026, Luis González Fernández, luisgf@luisgf.es
+        Copyright (c) 2014-2026, Jesús Cea Avión, jcea@jcea.es
+
+        All rights reserved.
+
+        This library is free software; you can redistribute it and/or
+        modify it under the terms of the GNU Lesser General Public
+        License as published by the Free Software Foundation; either
+        version 3.0 of the License, or (at your option) any later version.
+
+        This library is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+        Lesser General Public License for more details.
+
+        You should have received a copy of the GNU Lesser General Public
+        License along with this library.
+"""
+
+# DID resolution for OB3 issuer identity. Turns an issuer's DID into a PEM
+# public verification key, so a JWT-VC can be verified without the operator
+# supplying the key out-of-band.
+#
+# Supported methods:
+#   did:key  — self-certifying: the public key IS encoded in the identifier
+#              (multibase base58btc of a multicodec-prefixed key). No network.
+#   did:web  — trusts DNS + TLS for the host: fetches the DID document over
+#              HTTPS and reads its first verification method.
+#
+# Trust note: did:key needs no external trust (the key is the identifier).
+# did:web is only as trustworthy as the host's DNS and TLS. Neither is a
+# ledger/anchored method; did:ion, did:ethr, etc. are out of scope.
+
+import json
+
+from typing import Any
+
+from cryptography.hazmat.primitives import serialization as _serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from jwt.algorithms import OKPAlgorithm, ECAlgorithm, RSAAlgorithm
+
+from .verifier import OB3VerificationError
+from ..util import download_file
+
+# multicodec codes (unsigned varint) for the public key types we accept.
+_MULTICODEC_ED25519_PUB = 0xed    # followed by 32 raw bytes
+_MULTICODEC_P256_PUB = 0x1200     # followed by a 33-byte compressed point
+
+_B58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+_B58_INDEX = {c: i for i, c in enumerate(_B58_ALPHABET)}
+
+
+def resolve_did(did: str, download: Any = None) -> bytes:
+    """Resolve a DID to a PEM-encoded public key.
+
+    Supports did:key (offline) and did:web (one HTTPS fetch). Raises
+    OB3VerificationError for an unsupported method or any resolution failure.
+    ``download`` defaults to util.download_file; it is injectable for testing.
+    """
+    if not isinstance(did, str) or not did.startswith('did:'):
+        raise OB3VerificationError("not a DID: %r" % (did,))
+    fetch = download if download is not None else download_file
+    if did.startswith('did:key:'):
+        return _resolve_did_key(did)
+    if did.startswith('did:web:'):
+        return _resolve_did_web(did, fetch)
+    raise OB3VerificationError("unsupported DID method: %r" % did)
+
+
+# ── did:key ──────────────────────────────────────────────────────────────────
+
+def _resolve_did_key(did: str) -> bytes:
+    ident = did[len('did:key:'):]
+    if not ident.startswith('z'):
+        raise OB3VerificationError("did:key must use base58btc multibase (z…)")
+    return _multicodec_pubkey_to_pem(_b58btc_decode(ident[1:]))
+
+
+def _multicodec_pubkey_to_pem(data: bytes) -> bytes:
+    """Decode a multicodec-prefixed public key (as used by did:key and
+    publicKeyMultibase) into a SubjectPublicKeyInfo PEM."""
+    code, rest = _read_varint(data)
+    try:
+        if code == _MULTICODEC_ED25519_PUB:
+            return _public_key_to_pem(Ed25519PublicKey.from_public_bytes(rest))
+        if code == _MULTICODEC_P256_PUB:
+            return _public_key_to_pem(
+                ec.EllipticCurvePublicKey.from_encoded_point(ec.SECP256R1(), rest))
+    except ValueError as exc:
+        raise OB3VerificationError("malformed did:key public key: %s" % exc) from exc
+    raise OB3VerificationError("unsupported did:key multicodec 0x%x" % code)
+
+
+def _b58btc_decode(value: str) -> bytes:
+    num = 0
+    for ch in value:
+        idx = _B58_INDEX.get(ch)
+        if idx is None:
+            raise OB3VerificationError("invalid base58btc character %r" % ch)
+        num = num * 58 + idx
+    body = num.to_bytes((num.bit_length() + 7) // 8, 'big') if num else b''
+    n_pad = len(value) - len(value.lstrip('1'))   # leading '1' => leading 0x00
+    return b'\x00' * n_pad + body
+
+
+def _read_varint(data: bytes) -> Any:
+    result = shift = 0
+    for i, byte in enumerate(data):
+        result |= (byte & 0x7f) << shift
+        if not byte & 0x80:
+            return result, data[i + 1:]
+        shift += 7
+    raise OB3VerificationError("truncated multicodec varint")
+
+
+# ── did:web ──────────────────────────────────────────────────────────────────
+
+def _resolve_did_web(did: str, fetch: Any) -> bytes:
+    from urllib.parse import unquote
+    ident = did[len('did:web:'):]
+    if not ident:
+        raise OB3VerificationError("empty did:web identifier")
+    parts = [unquote(p) for p in ident.split(':')]
+    host, path_segments = parts[0], parts[1:]
+    if path_segments:
+        url = 'https://%s/%s/did.json' % (host, '/'.join(path_segments))
+    else:
+        url = 'https://%s/.well-known/did.json' % host
+
+    try:
+        raw = fetch(url)
+    except Exception as exc:
+        raise OB3VerificationError(
+            "could not fetch DID document %s: %s" % (url, exc)) from exc
+    try:
+        doc = json.loads(raw.decode('utf-8'))
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise OB3VerificationError(
+            "malformed DID document at %s: %s" % (url, exc)) from exc
+    return _pem_from_did_document(doc)
+
+
+def _pem_from_did_document(doc: Any) -> bytes:
+    if not isinstance(doc, dict):
+        raise OB3VerificationError("DID document is not a JSON object")
+    methods = doc.get('verificationMethod')
+    if not isinstance(methods, list) or not methods:
+        raise OB3VerificationError("DID document has no verificationMethod")
+    vm = methods[0]
+    if not isinstance(vm, dict):
+        raise OB3VerificationError("verificationMethod entry is not an object")
+
+    jwk = vm.get('publicKeyJwk')
+    if isinstance(jwk, dict):
+        return _jwk_to_pem(jwk)
+    multibase = vm.get('publicKeyMultibase')
+    if isinstance(multibase, str) and multibase.startswith('z'):
+        return _multicodec_pubkey_to_pem(_b58btc_decode(multibase[1:]))
+    raise OB3VerificationError(
+        "verificationMethod has no supported public key encoding "
+        "(publicKeyJwk or z-base58 publicKeyMultibase)")
+
+
+def _jwk_to_pem(jwk: dict) -> bytes:
+    kty = jwk.get('kty')
+    jwk_json = json.dumps(jwk)
+    key: Any
+    try:
+        if kty == 'OKP':
+            key = OKPAlgorithm.from_jwk(jwk_json)
+        elif kty == 'EC':
+            key = ECAlgorithm.from_jwk(jwk_json)
+        elif kty == 'RSA':
+            key = RSAAlgorithm.from_jwk(jwk_json)
+        else:
+            raise OB3VerificationError("unsupported JWK kty: %r" % (kty,))
+    except OB3VerificationError:
+        raise
+    except Exception as exc:
+        raise OB3VerificationError("malformed publicKeyJwk: %s" % exc) from exc
+    # A public JWK yields a public key; guard against a private one just in case.
+    if hasattr(key, 'public_bytes'):
+        return _public_key_to_pem(key)
+    return _public_key_to_pem(key.public_key())
+
+
+def _public_key_to_pem(key: Any) -> bytes:
+    return key.public_bytes(
+        _serialization.Encoding.PEM,
+        _serialization.PublicFormat.SubjectPublicKeyInfo)

--- a/openbadgeslib/ob3/verifier.py
+++ b/openbadgeslib/ob3/verifier.py
@@ -86,6 +86,18 @@ class OB3Verifier:
                 "Unsupported verification key type: %s" % exc) from exc
         self._allowed_algorithms = _ALGORITHMS_BY_KEY_TYPE[key_type]
 
+    @classmethod
+    def for_issuer_did(cls, did: str, download: Any = None) -> "OB3Verifier":
+        """Construct a verifier by resolving an issuer DID to its public key.
+
+        Supports did:key (offline) and did:web (one HTTPS fetch). Raises
+        OB3VerificationError for an unsupported method or a resolution failure.
+        Imported lazily so DID resolution (and its network path) is only pulled
+        in when a caller actually anchors trust on a DID.
+        """
+        from .did import resolve_did
+        return cls(pubkey_pem=resolve_did(did, download=download))
+
     # ── verification ───────────────────────────────────────────────────────────
 
     def verify(self, token: str,

--- a/openbadgeslib/openbadges_verifier.py
+++ b/openbadgeslib/openbadges_verifier.py
@@ -89,6 +89,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument('--check-status', action='store_true',
                         help='OB3 only: fetch the credentialStatus list and reject a '
                              'revoked/suspended credential (requires network access).')
+    parser.add_argument('--resolve-did', action='store_true',
+                        help='OB3 only: when no trusted key is supplied, resolve the '
+                             'issuer DID (did:key/did:web) from the token to obtain the '
+                             'verification key (did:web requires network access).')
     parser.add_argument('-V', '--ob-version', choices=['2', '3'], default='2',
                         metavar='VERSION',
                         help='OpenBadges specification version: 2 (default, JWS) or 3 (JWT-VC).')
@@ -163,14 +167,38 @@ def _verify_ob2(args: argparse.Namespace) -> None:
         sys.exit(-1)
 
 
+def _issuer_did_from_token(token: str) -> str:
+    """Read the issuer DID from an unverified JWT-VC (iss, or vc.issuer.id).
+
+    Only used to anchor trust when --resolve-did is set: the DID is read from
+    the untrusted token, resolved to a key, and the signature is then checked
+    against that key (did:key is self-certifying; did:web trusts DNS+TLS)."""
+    import jwt
+    from .ob3 import OB3VerificationError
+    try:
+        payload = jwt.decode(token, options={'verify_signature': False})
+    except jwt.exceptions.PyJWTError as exc:
+        raise OB3VerificationError('could not read token issuer: %s' % exc) from exc
+    iss = payload.get('iss')
+    if not iss:
+        vc = payload.get('vc')
+        if not isinstance(vc, dict):
+            vc = {}
+        issuer = vc.get('issuer')
+        iss = issuer.get('id') if isinstance(issuer, dict) else issuer
+    if not isinstance(iss, str) or not iss.startswith('did:'):
+        raise OB3VerificationError('token issuer is not a DID: %r' % (iss,))
+    return iss
+
+
 def _verify_ob3(args: argparse.Namespace) -> None:
     """Verify a badge using OpenBadges 3.0 (JWT-VC)."""
     from .ob3 import OB3Verifier, OB3VerificationError
     from .errors import ErrorParsingFile
 
     pub_pem = _resolve_trusted_pubkey(args)
-    if pub_pem is None:
-        print('[!] OB3 verification requires --local BADGE or --pubkey FILE')
+    if pub_pem is None and not args.resolve_did:
+        print('[!] OB3 verification requires --local BADGE, --pubkey FILE, or --resolve-did')
         sys.exit(-1)
 
     with open(args.filein, 'rb') as f:
@@ -191,7 +219,12 @@ def _verify_ob3(args: argparse.Namespace) -> None:
     # Let the library own recipient binding (it normalises mailto:/DID and
     # compares), instead of re-implementing the comparison here.
     try:
-        verifier = OB3Verifier(pubkey_pem=pub_pem)
+        if pub_pem is not None:
+            verifier = OB3Verifier(pubkey_pem=pub_pem)
+        else:
+            issuer_did = _issuer_did_from_token(token)
+            print('[*] Resolving issuer DID %s' % issuer_did)
+            verifier = OB3Verifier.for_issuer_did(issuer_did)
         credential = verifier.verify(token, expected_recipient=args.receptor,
                                      check_status=args.check_status)
     except OB3VerificationError as exc:

--- a/tests/test_ob3_did.py
+++ b/tests/test_ob3_did.py
@@ -1,0 +1,191 @@
+"""Tests for DID resolution (did:key, did:web) — ob3.did."""
+import base64
+import json
+
+import pytest
+
+from cryptography.hazmat.primitives import serialization as ser
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from openbadgeslib.ob3 import resolve_did, OB3Verifier, OB3VerificationError
+from openbadgeslib.keys import detect_key_type, KeyType
+
+
+_B58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+
+
+def _b58encode(data: bytes) -> str:
+    n = int.from_bytes(data, 'big')
+    out = ''
+    while n > 0:
+        n, r = divmod(n, 58)
+        out = _B58[r] + out
+    pad = len(data) - len(data.lstrip(b'\x00'))
+    return '1' * pad + out
+
+
+def _did_key_ed25519(pub) -> str:
+    raw = pub.public_bytes(ser.Encoding.Raw, ser.PublicFormat.Raw)
+    return 'did:key:z' + _b58encode(b'\xed\x01' + raw)
+
+
+def _did_key_p256(pub) -> str:
+    point = pub.public_bytes(ser.Encoding.X962, ser.PublicFormat.CompressedPoint)
+    return 'did:key:z' + _b58encode(b'\x80\x24' + point)
+
+
+def _b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode('ascii').rstrip('=')
+
+
+def _did_web_doc(vm_public):
+    return {
+        "id": "did:web:issuer.example",
+        "verificationMethod": [
+            {"id": "did:web:issuer.example#key-1",
+             "type": "JsonWebKey2020",
+             "controller": "did:web:issuer.example",
+             **vm_public},
+        ],
+    }
+
+
+# ── did:key ──────────────────────────────────────────────────────────────────
+
+class TestDidKey:
+    def test_ed25519_resolves_to_matching_pem(self, ed25519_pub_pem):
+        pub = ser.load_pem_public_key(ed25519_pub_pem)
+        pem = resolve_did(_did_key_ed25519(pub))
+        assert detect_key_type(pem) is KeyType.ED25519
+        assert pem == ed25519_pub_pem
+
+    def test_p256_resolves_to_ecc(self):
+        priv = ec.generate_private_key(ec.SECP256R1())
+        pem = resolve_did(_did_key_p256(priv.public_key()))
+        assert detect_key_type(pem) is KeyType.ECC
+
+    def test_bad_base58_rejected(self):
+        with pytest.raises(OB3VerificationError, match='base58'):
+            resolve_did('did:key:z0OIl')   # 0, O, I, l are not in the alphabet
+
+    def test_non_z_multibase_rejected(self):
+        with pytest.raises(OB3VerificationError, match='base58btc'):
+            resolve_did('did:key:Qabc')
+
+    def test_unsupported_multicodec_rejected(self):
+        # multicodec 0x99 0x01 (arbitrary/unsupported) + junk
+        raw = bytes([0x99, 0x01]) + b'\x00' * 32
+        with pytest.raises(OB3VerificationError, match='multicodec'):
+            resolve_did('did:key:z' + _b58encode(raw))
+
+
+# ── did:web ──────────────────────────────────────────────────────────────────
+
+class TestDidWeb:
+    def _fetch(self, doc, expected_url):
+        def _dl(url):
+            assert url == expected_url, url
+            return json.dumps(doc).encode('utf-8')
+        return _dl
+
+    def test_well_known_path(self, ed25519_pub_pem):
+        pub = ser.load_pem_public_key(ed25519_pub_pem)
+        raw = pub.public_bytes(ser.Encoding.Raw, ser.PublicFormat.Raw)
+        jwk = {"kty": "OKP", "crv": "Ed25519", "x": _b64url(raw)}
+        doc = _did_web_doc({"publicKeyJwk": jwk})
+        fetch = self._fetch(doc, 'https://issuer.example/.well-known/did.json')
+        pem = resolve_did('did:web:issuer.example', download=fetch)
+        assert pem == ed25519_pub_pem
+
+    def test_path_based(self, ed25519_pub_pem):
+        pub = ser.load_pem_public_key(ed25519_pub_pem)
+        raw = pub.public_bytes(ser.Encoding.Raw, ser.PublicFormat.Raw)
+        jwk = {"kty": "OKP", "crv": "Ed25519", "x": _b64url(raw)}
+        doc = _did_web_doc({"publicKeyJwk": jwk})
+        fetch = self._fetch(doc, 'https://issuer.example/users/alice/did.json')
+        pem = resolve_did('did:web:issuer.example:users:alice', download=fetch)
+        assert detect_key_type(pem) is KeyType.ED25519
+
+    def test_public_key_multibase(self, ed25519_pub_pem):
+        pub = ser.load_pem_public_key(ed25519_pub_pem)
+        mb = _did_key_ed25519(pub).split('did:key:')[1]  # 'z...'
+        doc = _did_web_doc({"publicKeyMultibase": mb})
+        fetch = self._fetch(doc, 'https://issuer.example/.well-known/did.json')
+        pem = resolve_did('did:web:issuer.example', download=fetch)
+        assert pem == ed25519_pub_pem
+
+    def test_rsa_jwk(self, rsa_pub_pem):
+        from jwt.algorithms import RSAAlgorithm
+        jwk = json.loads(RSAAlgorithm.to_jwk(ser.load_pem_public_key(rsa_pub_pem)))
+        doc = _did_web_doc({"publicKeyJwk": jwk})
+        fetch = self._fetch(doc, 'https://issuer.example/.well-known/did.json')
+        pem = resolve_did('did:web:issuer.example', download=fetch)
+        assert detect_key_type(pem) is KeyType.RSA
+
+    def test_fetch_error_wrapped(self):
+        def _boom(url):
+            raise ValueError('insecure scheme')
+        with pytest.raises(OB3VerificationError, match='could not fetch'):
+            resolve_did('did:web:issuer.example', download=_boom)
+
+    def test_no_verification_method(self):
+        fetch = self._fetch({"id": "did:web:issuer.example"},
+                            'https://issuer.example/.well-known/did.json')
+        with pytest.raises(OB3VerificationError, match='verificationMethod'):
+            resolve_did('did:web:issuer.example', download=fetch)
+
+    def test_malformed_document(self):
+        with pytest.raises(OB3VerificationError, match='malformed'):
+            resolve_did('did:web:issuer.example', download=lambda url: b'not json')
+
+
+# ── method dispatch ──────────────────────────────────────────────────────────
+
+class TestResolveDidDispatch:
+    def test_non_did_rejected(self):
+        with pytest.raises(OB3VerificationError, match='not a DID'):
+            resolve_did('https://issuer.example/key.pem')
+
+    def test_unsupported_method_rejected(self):
+        with pytest.raises(OB3VerificationError, match='unsupported DID method'):
+            resolve_did('did:ion:EiClk...')
+
+
+# ── end-to-end through OB3Verifier.for_issuer_did ────────────────────────────
+
+class TestForIssuerDid:
+    def test_verify_token_signed_by_did_key(self, ed25519_priv_pem, ed25519_pub_pem):
+        from openbadgeslib.ob3 import OB3Signer, Achievement, Issuer, OpenBadgeCredential
+        pub = ser.load_pem_public_key(ed25519_pub_pem)
+        did = _did_key_ed25519(pub)
+
+        credential = OpenBadgeCredential(
+            id='urn:uuid:00000000-0000-0000-0000-0000000000cc',
+            issuer=Issuer(id=did, name='DID Issuer'),
+            recipient_id='mailto:r@example.com',
+            achievement=Achievement(id='https://a.example/1', name='A',
+                                    description='d', criteria_narrative='c'),
+        )
+        token = OB3Signer(privkey_pem=ed25519_priv_pem, algorithm='EdDSA').sign(credential)
+
+        verifier = OB3Verifier.for_issuer_did(did)     # did:key, offline
+        cred = verifier.verify(token)
+        assert cred.issuer.id == did
+
+    def test_wrong_did_key_fails_verification(self, ed25519_priv_pem):
+        from openbadgeslib.ob3 import OB3Signer, Achievement, Issuer, OpenBadgeCredential
+        # Sign with our key but hand for_issuer_did a DIFFERENT did:key.
+        other = Ed25519PrivateKey.generate().public_key()
+        wrong_did = _did_key_ed25519(other)
+        credential = OpenBadgeCredential(
+            id='urn:uuid:00000000-0000-0000-0000-0000000000cd',
+            issuer=Issuer(id=wrong_did, name='I'),
+            recipient_id='mailto:r@example.com',
+            achievement=Achievement(id='https://a.example/1', name='A',
+                                    description='d', criteria_narrative='c'),
+        )
+        token = OB3Signer(privkey_pem=ed25519_priv_pem, algorithm='EdDSA').sign(credential)
+        verifier = OB3Verifier.for_issuer_did(wrong_did)
+        with pytest.raises(OB3VerificationError):
+            verifier.verify(token)

--- a/wiki/CLI-Reference.md
+++ b/wiki/CLI-Reference.md
@@ -122,7 +122,7 @@ Extracts the embedded assertion/credential from a signed badge image, checks the
 ### Synopsis
 
 ```sh
-openbadges-verifier -i FILE -r RECEPTOR [-l BADGE | -k FILE] [-c FILE] [-s] [--check-status] [-V {2,3}] [-d]
+openbadges-verifier -i FILE -r RECEPTOR [-l BADGE | -k FILE] [-c FILE] [-s] [--check-status] [--resolve-did] [-V {2,3}] [-d]
 ```
 
 | Short | Long | Meaning | Default |
@@ -134,6 +134,7 @@ openbadges-verifier -i FILE -r RECEPTOR [-l BADGE | -k FILE] [-c FILE] [-s] [--c
 | `-k` | `--pubkey FILE` | Verify against this trusted PEM public key file (OB2 and OB3) | none |
 | `-s` | `--show` | Print the assertion/credential before the result | off |
 | | `--check-status` | OB3 only: fetch the `credentialStatus` list and reject a revoked/suspended credential (requires network) | off |
+| | `--resolve-did` | OB3 only: when no trusted key is given, resolve the issuer DID (did:key/did:web) from the token to obtain the verification key | off |
 | `-V` | `--ob-version {2,3}` | `2` = JWS, `3` = JWT-VC | `2` |
 | `-d` | `--debug` | Show debug messages at runtime | off |
 | `-v` | `--version` | Print version and exit | — |
@@ -165,7 +166,9 @@ $ openbadges-verifier -i /tmp/badge_1_recipient@example.com.svg \
 [+] OB3 signature is valid for the identity recipient@example.com
 ```
 
-OB3 without `-l`/`-k` exits with `[!] OB3 verification requires --local BADGE or --pubkey FILE`. OB3 verification only supports `.svg` and `.png` inputs.
+OB3 without `-l`/`-k`/`--resolve-did` exits with `[!] OB3 verification requires --local BADGE, --pubkey FILE, or --resolve-did`. OB3 verification only supports `.svg` and `.png` inputs.
+
+With `--resolve-did` and no explicit key, the issuer DID is read from the (still-unverified) token and resolved to a key, and the signature is then checked against it. `did:key` is self-certifying (the key is encoded in the identifier) and needs no network; `did:web` fetches `https://<host>/.well-known/did.json` (or a path-based `did.json`) and therefore trusts the host's DNS and TLS. See [[Security Model]].
 
 ## openbadges-publish
 

--- a/wiki/Security-Model.md
+++ b/wiki/Security-Model.md
@@ -106,6 +106,12 @@ if not revocation_url:
 
 Note the trust implication: revocation is fetched from the **issuer's host** over HTTPS. The result is only as trustworthy as that host and its TLS. An absent `revocationList` means "no revocations published", which is treated as not-revoked. All issuer/revocation downloads and JSON parses are guarded — a missing or malformed document raises a clean library error instead of a raw crash.
 
+### OB3 revocation via credentialStatus
+
+The OB3 equivalent is `credentialStatus` (W3C Bitstring Status List v1.0, or the legacy StatusList2021). It is **opt-in** — `OB3Verifier.verify(..., check_status=True)` or the `--check-status` CLI flag — because verification is otherwise fully offline. When enabled, each status entry's `statusListCredential` is fetched over HTTPS, its `encodedList` is base64url-decoded and GZIP-inflated under a size cap (a bounded inflate, so a crafted status list cannot exhaust memory), and the bit at `statusListIndex` is read (MSB-first). A set revocation/suspension bit fails verification.
+
+The check is **fail-closed**: if the status list cannot be fetched or parsed, verification fails rather than passing. It verifies the *published status bit* only — it does **not** verify the status-list credential's own signature, which is a separate trust chain (often a different key); a deployment needing that guarantee must verify the status-list credential independently.
+
 ### Recipient / identity binding
 
 The signature does not, by itself, bind a badge to a particular recipient — you must request that check explicitly, otherwise it is skipped (not silently failed).
@@ -125,6 +131,15 @@ if sub is not None and sub != (vc.get("credentialSubject") or {}).get("id"):
 ```
 
 It also requires the `vc` claim to be present and to carry the `OpenBadgeCredential` type, so an OB2 JWS token (which has no `vc` claim) is rejected with a clear message rather than misinterpreted.
+
+### DID-based issuer identity (OB3)
+
+`OB3Verifier.for_issuer_did(did)` (and the verifier's `--resolve-did` flag) turn an issuer DID into a verification key. Two methods are supported, each with a different trust anchor:
+
+- **did:key** is *self-certifying*: the public key is encoded directly in the identifier (multibase base58btc of a multicodec-prefixed key). Resolving it needs no network and no external trust — the key **is** the identifier.
+- **did:web** trusts the host's **DNS and TLS**: the DID document is fetched from `https://<host>/.well-known/did.json` (or a path-based `did.json`) using the same HTTPS-only, size-capped downloader, and its first verification method (`publicKeyJwk` or `publicKeyMultibase`) is used.
+
+When `--resolve-did` is used, the DID is read from the still-unverified token and resolved; the signature is then checked against the resolved key. Because the DID is the issuer's own claimed identity, this is legitimate trust anchoring for `did:key`/`did:web` — but it is only as strong as that method's anchor (nothing for did:key beyond the key itself; DNS+TLS for did:web). Ledger/anchored methods (did:ion, did:ethr, …) are not resolved.
 
 Beyond the claim cross-checks, the `vc` body itself is untrusted input, so `from_jwt_payload` validates its **structure** explicitly: every required object (`issuer`, `credentialSubject`, `achievement`) must be a JSON object, the required identity fields (`vc.id`, `issuer.id`, `credentialSubject.id`, `achievement.id`/`name`) must be present and non-empty, dates must be valid ISO 8601, and `credentialSubject` may be a single object or a non-empty array. A malformed credential is rejected with an `OB3VerificationError` that names the offending field, never a raw `KeyError`/`TypeError`.
 


### PR DESCRIPTION
Add ob3/did.py with resolve_did() and OB3Verifier.for_issuer_did(),
turning an OB3 issuer DID into a PEM verification key:

  - did:key: self-certifying, offline — multibase base58btc of a
    multicodec-prefixed key (Ed25519 and P-256 supported).
  - did:web: fetches https://<host>/.well-known/did.json (or a path-based
    did.json) over the HTTPS-only, size-capped download_file and reads the
    first verificationMethod's publicKeyJwk or publicKeyMultibase.

openbadges-verifier gains --resolve-did: with no explicit key for an OB3
badge, the issuer DID is read from the (still-unverified) token, resolved,
and the signature is then checked against the resolved key. did:key needs no
external trust; did:web trusts the host's DNS+TLS (documented in the Security
Model). Unsupported methods and malformed material raise a clean
OB3VerificationError.

Fixes #105

VERIFIED: flake8, mypy, and pytest (474 passed, +16 new DID tests incl.
did:key round-trip, did:web JWK/multibase, wrong-DID rejection, and error
paths) all green; CLI-Reference and Security-Model document --resolve-did.
