### PR TITLE
feat(verifier): add --json machine-readable output

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,6 +6,14 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
 
 * Unreleased
 
+  - feat: openbadges-verifier gained a --json flag for machine-readable output.
+    It prints a single JSON object ({valid, ob_version, recipient, reason, and
+    version-specific fields such as OB2 trusted/status or OB3
+    issuer/achievement/…}) instead of the human [+]/[-]/[~] lines, and exits 0
+    when valid / non-zero otherwise — usable in CI and services without
+    scraping stdout. The default (human) output and its exit codes are
+    unchanged.
+
   - feat: OB3 issuer DIDs can now be resolved to a verification key. New
     ob3.resolve_did() and OB3Verifier.for_issuer_did() support did:key (Ed25519
     and P-256, self-certifying, offline) and did:web (fetches the DID document

--- a/openbadgeslib/openbadges_verifier.py
+++ b/openbadgeslib/openbadges_verifier.py
@@ -30,11 +30,12 @@
 """
 
 import argparse
+import json
 import logging
 import sys
 import os
 
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from .errors import LibOpenBadgesException
 from .confparser import read_config_or_exit, resolve_badge_section
@@ -96,11 +97,30 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument('-V', '--ob-version', choices=['2', '3'], default='2',
                         metavar='VERSION',
                         help='OpenBadges specification version: 2 (default, JWS) or 3 (JWT-VC).')
+    parser.add_argument('--json', action='store_true',
+                        help='Emit a machine-readable JSON result instead of the human '
+                             'output. Exits 0 when valid, non-zero otherwise.')
     parser.add_argument('-d', '--debug', action='store_true',
                         help='Show debug messages at runtime.')
     parser.add_argument('-v', '--version', action='version',
                         version=__version__)
     return parser
+
+
+def _finish(args: argparse.Namespace, result: Dict[str, Any]) -> None:
+    """Emit the verification result and set the process exit status.
+
+    In --json mode a single JSON object is printed and the process exits 0 when
+    valid, non-zero otherwise. Without --json the human lines have already been
+    printed; the historical exit behaviour is preserved via result['_exit']
+    (None means return without exiting, i.e. a normal exit 0)."""
+    if args.json:
+        payload = {k: v for k, v in result.items() if not k.startswith('_')}
+        print(json.dumps(payload))
+        sys.exit(0 if result.get('valid') else 1)
+    code = result.get('_exit')
+    if code is not None:
+        sys.exit(code)
 
 
 def main() -> None:
@@ -116,8 +136,13 @@ def main() -> None:
                  args.filein, args.ob_version, args.receptor)
 
     if not os.path.isfile(args.filein):
-        print('[!] Badge file %s NOT exists.' % args.filein)
-        sys.exit(-1)
+        if not args.json:
+            print('[!] Badge file %s NOT exists.' % args.filein)
+        _finish(args, {'ob_version': args.ob_version, 'recipient': args.receptor,
+                       'valid': False,
+                       'reason': 'Badge file %s does not exist' % args.filein,
+                       '_exit': -1})
+        return
 
     if args.ob_version == '3':
         _verify_ob3(args)
@@ -127,6 +152,7 @@ def main() -> None:
 
 def _verify_ob2(args: argparse.Namespace) -> None:
     """Verify a badge using OpenBadges 2.0 (JWS)."""
+    result: Dict[str, Any] = {'ob_version': '2', 'recipient': args.receptor, '_exit': None}
     try:
         badge = BadgeSigned.read_from_file(args.filein)
 
@@ -140,31 +166,47 @@ def _verify_ob2(args: argparse.Namespace) -> None:
                      trusted, 'operator' if trusted else 'badge-embedded')
 
         v = Verifier(verify_key=local_pubkey, identity=args.receptor)
-        if args.show:
+        if args.show and not args.json:
             v.print_payload(badge)
 
         check = v.get_badge_status(badge)
         logger.debug("OB2 verify result: %s", check.status.name)
+        result['trusted'] = trusted
+        result['status'] = check.status.name
 
         if check.status is BadgeStatus.VALID:
+            result['valid'] = True
             if trusted:
-                print('[+] Signature is correct for the identity %s' % v.get_identity())
+                result['reason'] = None
+                if not args.json:
+                    print('[+] Signature is correct for the identity %s' % v.get_identity())
             else:
-                print('[~] Signature is internally consistent for %s, but it was '
-                      'verified against the key embedded in the badge itself, not a '
-                      'trusted issuer key. This does NOT prove issuer identity. '
-                      'Re-run with --local BADGE or --pubkey FILE to anchor trust.'
-                      % v.get_identity())
+                result['reason'] = ('signature is internally consistent but verified against '
+                                    'the badge-embedded key, not a trusted issuer key')
+                if not args.json:
+                    print('[~] Signature is internally consistent for %s, but it was '
+                          'verified against the key embedded in the badge itself, not a '
+                          'trusted issuer key. This does NOT prove issuer identity. '
+                          'Re-run with --local BADGE or --pubkey FILE to anchor trust.'
+                          % v.get_identity())
         else:
-            print('[-] ', check.msg)
+            result['valid'] = False
+            result['reason'] = check.msg
+            if not args.json:
+                print('[-] ', check.msg)
 
     except LibOpenBadgesException as exc:
         # Present any library exception (unsupported image format, malformed
         # assertion, unreadable key material, …) as a clean CLI error rather
         # than an uncaught traceback. BadgeImgFormatUnsupported and the key-read
         # errors inherit LibOpenBadgesException but not VerifierExceptions.
-        print('[-] %s' % exc)
-        sys.exit(-1)
+        result['valid'] = False
+        result['reason'] = str(exc)
+        result['_exit'] = -1
+        if not args.json:
+            print('[-] %s' % exc)
+
+    _finish(args, result)
 
 
 def _issuer_did_from_token(token: str) -> str:
@@ -196,10 +238,16 @@ def _verify_ob3(args: argparse.Namespace) -> None:
     from .ob3 import OB3Verifier, OB3VerificationError
     from .errors import ErrorParsingFile
 
+    result: Dict[str, Any] = {'ob_version': '3', 'recipient': args.receptor,
+                              'trusted': True, 'valid': False, '_exit': -1}
+
     pub_pem = _resolve_trusted_pubkey(args)
     if pub_pem is None and not args.resolve_did:
-        print('[!] OB3 verification requires --local BADGE, --pubkey FILE, or --resolve-did')
-        sys.exit(-1)
+        result['reason'] = 'OB3 verification requires --local BADGE, --pubkey FILE, or --resolve-did'
+        if not args.json:
+            print('[!] %s' % result['reason'])
+        _finish(args, result)
+        return
 
     with open(args.filein, 'rb') as f:
         file_data = f.read()
@@ -210,11 +258,17 @@ def _verify_ob3(args: argparse.Namespace) -> None:
         elif args.filein.lower().endswith('.png'):
             token = OB3Verifier.extract_token_from_png(file_data)
         else:
-            print('[!] Unsupported file format for OB3 verification (use .svg or .png)')
-            sys.exit(-1)
+            result['reason'] = 'Unsupported file format for OB3 verification (use .svg or .png)'
+            if not args.json:
+                print('[!] %s' % result['reason'])
+            _finish(args, result)
+            return
     except (OB3VerificationError, ErrorParsingFile) as exc:
-        print('[-] Could not extract OB3 token: %s' % exc)
-        sys.exit(-1)
+        result['reason'] = 'Could not extract OB3 token: %s' % exc
+        if not args.json:
+            print('[-] %s' % result['reason'])
+        _finish(args, result)
+        return
 
     # Let the library own recipient binding (it normalises mailto:/DID and
     # compares), instead of re-implementing the comparison here.
@@ -223,15 +277,30 @@ def _verify_ob3(args: argparse.Namespace) -> None:
             verifier = OB3Verifier(pubkey_pem=pub_pem)
         else:
             issuer_did = _issuer_did_from_token(token)
-            print('[*] Resolving issuer DID %s' % issuer_did)
+            result['issuer_did'] = issuer_did
+            if not args.json:
+                print('[*] Resolving issuer DID %s' % issuer_did)
             verifier = OB3Verifier.for_issuer_did(issuer_did)
         credential = verifier.verify(token, expected_recipient=args.receptor,
                                      check_status=args.check_status)
     except OB3VerificationError as exc:
-        print('[-] OB3 verification failed: %s' % exc)
-        sys.exit(-1)
+        result['reason'] = 'OB3 verification failed: %s' % exc
+        if not args.json:
+            print('[-] %s' % result['reason'])
+        _finish(args, result)
+        return
 
-    if args.show:
+    result['valid'] = True
+    result['reason'] = None
+    result['_exit'] = None
+    result['issuer'] = credential.issuer.name
+    result['achievement'] = credential.achievement.name
+    result['issued_on'] = credential.issuance_date.isoformat() if credential.issuance_date else None
+    result['expires'] = (credential.expiration_date.isoformat()
+                         if credential.expiration_date else None)
+    result['evidence'] = credential.evidence_url
+
+    if args.show and not args.json:
         print('[+] Credential issuer  : %s' % credential.issuer.name)
         print('[+] Achievement        : %s' % credential.achievement.name)
         issued = credential.issuance_date.isoformat() if credential.issuance_date else 'n/a'
@@ -241,7 +310,10 @@ def _verify_ob3(args: argparse.Namespace) -> None:
         if credential.evidence_url:
             print('[+] Evidence           : %s' % credential.evidence_url)
 
-    print('[+] OB3 signature is valid for the identity %s' % args.receptor)
+    if not args.json:
+        print('[+] OB3 signature is valid for the identity %s' % args.receptor)
+
+    _finish(args, result)
 
 
 if __name__ == '__main__':

--- a/tests/test_cli_json.py
+++ b/tests/test_cli_json.py
@@ -1,0 +1,149 @@
+"""Tests for openbadges-verifier --json machine-readable output."""
+import json
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from openbadgeslib import openbadges_verifier
+
+
+def _fake_revocation_download(url, *a, **k):
+    if url.endswith('badge.json'):
+        return json.dumps({'issuer': 'https://example.com/issuer.json'}).encode()
+    return json.dumps({}).encode()
+
+
+def _run(argv, capsys, extra_patches=()):
+    """Run main() with the given argv, returning (exit_code, parsed_json)."""
+    with patch.object(sys, 'argv', argv):
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            for p in extra_patches:
+                stack.enter_context(p)
+            with pytest.raises(SystemExit) as exc:
+                openbadges_verifier.main()
+    out = capsys.readouterr().out
+    # --json must emit exactly one JSON object and no human [+]/[-]/[~] lines.
+    assert '[+]' not in out and '[-]' not in out and '[~]' not in out
+    return exc.value.code, json.loads(out)
+
+
+# ── OB3 ──────────────────────────────────────────────────────────────────────
+
+def _ob3_badge(tmp_path, priv_pem, svg_image, recipient='mailto:recipient@example.com'):
+    from openbadgeslib.ob3 import OB3Signer, Issuer, Achievement, OpenBadgeCredential
+    signer = OB3Signer(privkey_pem=priv_pem, algorithm='RS256')
+    cred = OpenBadgeCredential(
+        issuer=Issuer(id='https://example.com/issuer', name='Issuer'),
+        recipient_id=recipient,
+        achievement=Achievement(id='https://example.com/a', name='A',
+                                description='d', criteria_narrative='c'),
+    )
+    badge_file = tmp_path / 'badge.svg'
+    badge_file.write_bytes(signer.sign_into_svg(cred, svg_image))
+    return badge_file
+
+
+def test_ob3_valid_json(tmp_path, rsa_priv_pem, rsa_pub_pem, svg_image, capsys):
+    badge = _ob3_badge(tmp_path, rsa_priv_pem, svg_image)
+    pub = tmp_path / 'verify.pem'
+    pub.write_bytes(rsa_pub_pem)
+    argv = ['openbadges-verifier', '-i', str(badge), '-r', 'recipient@example.com',
+            '-V', '3', '-k', str(pub), '--json']
+    code, result = _run(argv, capsys)
+    assert code == 0
+    assert result['valid'] is True
+    assert result['ob_version'] == '3'
+    assert result['issuer'] == 'Issuer'
+    assert result['achievement'] == 'A'
+    assert result['reason'] is None
+
+
+def test_ob3_wrong_receptor_json(tmp_path, rsa_priv_pem, rsa_pub_pem, svg_image, capsys):
+    badge = _ob3_badge(tmp_path, rsa_priv_pem, svg_image)
+    pub = tmp_path / 'verify.pem'
+    pub.write_bytes(rsa_pub_pem)
+    argv = ['openbadges-verifier', '-i', str(badge), '-r', 'someone-else@example.com',
+            '-V', '3', '-k', str(pub), '--json']
+    code, result = _run(argv, capsys)
+    assert code != 0
+    assert result['valid'] is False
+    assert 'reason' in result and result['reason']
+
+
+def test_ob3_no_key_json(tmp_path, rsa_priv_pem, svg_image, capsys):
+    badge = _ob3_badge(tmp_path, rsa_priv_pem, svg_image)
+    argv = ['openbadges-verifier', '-i', str(badge), '-r', 'recipient@example.com',
+            '-V', '3', '--json']
+    code, result = _run(argv, capsys)
+    assert code != 0
+    assert result['valid'] is False
+    assert 'requires' in result['reason']
+
+
+# ── OB2 ──────────────────────────────────────────────────────────────────────
+
+def _make_signed_ob2_svg(tmp_path, badge, identity='recipient@example.com'):
+    from openbadgeslib.signer import Signer
+    from openbadgeslib.badge import BadgeType
+    signed = Signer(identity=identity, badge_type=BadgeType.SIGNED,
+                    deterministic=True).sign_badge(badge)
+    badge_file = tmp_path / 'badge.svg'
+    badge_file.write_bytes(signed.signed)
+    return badge_file
+
+
+def test_ob2_valid_trusted_json(tmp_path, svg_rsa_badge, rsa_pub_pem, capsys):
+    badge_file = _make_signed_ob2_svg(tmp_path, svg_rsa_badge)
+    pub = tmp_path / 'verify.pem'
+    pub.write_bytes(rsa_pub_pem)
+    argv = ['openbadges-verifier', '-i', str(badge_file), '-r', 'recipient@example.com',
+            '-V', '2', '-k', str(pub), '--json']
+    code, result = _run(argv, capsys, extra_patches=(
+        patch('openbadgeslib.ob2.badge.download_file', return_value=rsa_pub_pem),
+        patch('openbadgeslib.ob2.verifier.download_file', side_effect=_fake_revocation_download),
+    ))
+    assert code == 0
+    assert result['valid'] is True
+    assert result['trusted'] is True
+    assert result['status'] == 'VALID'
+    assert result['ob_version'] == '2'
+
+
+def test_ob2_untrusted_is_valid_but_not_trusted_json(tmp_path, svg_rsa_badge, rsa_pub_pem, capsys):
+    badge_file = _make_signed_ob2_svg(tmp_path, svg_rsa_badge)
+    argv = ['openbadges-verifier', '-i', str(badge_file), '-r', 'recipient@example.com',
+            '-V', '2', '--json']
+    code, result = _run(argv, capsys, extra_patches=(
+        patch('openbadgeslib.ob2.badge.download_file', return_value=rsa_pub_pem),
+        patch('openbadgeslib.ob2.verifier.download_file', side_effect=_fake_revocation_download),
+    ))
+    assert code == 0
+    assert result['valid'] is True
+    assert result['trusted'] is False
+
+
+def test_ob2_wrong_receptor_json_exits_nonzero(tmp_path, svg_rsa_badge, rsa_pub_pem, capsys):
+    badge_file = _make_signed_ob2_svg(tmp_path, svg_rsa_badge)
+    pub = tmp_path / 'verify.pem'
+    pub.write_bytes(rsa_pub_pem)
+    argv = ['openbadges-verifier', '-i', str(badge_file), '-r', 'someone-else@example.com',
+            '-V', '2', '-k', str(pub), '--json']
+    code, result = _run(argv, capsys, extra_patches=(
+        patch('openbadgeslib.ob2.badge.download_file', return_value=rsa_pub_pem),
+        patch('openbadgeslib.ob2.verifier.download_file', side_effect=_fake_revocation_download),
+    ))
+    assert code != 0
+    assert result['valid'] is False
+
+
+# ── shared ───────────────────────────────────────────────────────────────────
+
+def test_missing_file_json(tmp_path, capsys):
+    argv = ['openbadges-verifier', '-i', str(tmp_path / 'nope.svg'),
+            '-r', 'recipient@example.com', '-V', '2', '--json']
+    code, result = _run(argv, capsys)
+    assert code != 0
+    assert result['valid'] is False
+    assert 'does not exist' in result['reason']

--- a/wiki/CLI-Reference.md
+++ b/wiki/CLI-Reference.md
@@ -122,7 +122,7 @@ Extracts the embedded assertion/credential from a signed badge image, checks the
 ### Synopsis
 
 ```sh
-openbadges-verifier -i FILE -r RECEPTOR [-l BADGE | -k FILE] [-c FILE] [-s] [--check-status] [--resolve-did] [-V {2,3}] [-d]
+openbadges-verifier -i FILE -r RECEPTOR [-l BADGE | -k FILE] [-c FILE] [-s] [--check-status] [--resolve-did] [--json] [-V {2,3}] [-d]
 ```
 
 | Short | Long | Meaning | Default |
@@ -135,6 +135,7 @@ openbadges-verifier -i FILE -r RECEPTOR [-l BADGE | -k FILE] [-c FILE] [-s] [--c
 | `-s` | `--show` | Print the assertion/credential before the result | off |
 | | `--check-status` | OB3 only: fetch the `credentialStatus` list and reject a revoked/suspended credential (requires network) | off |
 | | `--resolve-did` | OB3 only: when no trusted key is given, resolve the issuer DID (did:key/did:web) from the token to obtain the verification key | off |
+| | `--json` | Emit a machine-readable JSON result instead of the human output (exit 0 valid, non-zero otherwise) | off |
 | `-V` | `--ob-version {2,3}` | `2` = JWS, `3` = JWT-VC | `2` |
 | `-d` | `--debug` | Show debug messages at runtime | off |
 | `-v` | `--version` | Print version and exit | — |
@@ -169,6 +170,15 @@ $ openbadges-verifier -i /tmp/badge_1_recipient@example.com.svg \
 OB3 without `-l`/`-k`/`--resolve-did` exits with `[!] OB3 verification requires --local BADGE, --pubkey FILE, or --resolve-did`. OB3 verification only supports `.svg` and `.png` inputs.
 
 With `--resolve-did` and no explicit key, the issuer DID is read from the (still-unverified) token and resolved to a key, and the signature is then checked against it. `did:key` is self-certifying (the key is encoded in the identifier) and needs no network; `did:web` fetches `https://<host>/.well-known/did.json` (or a path-based `did.json`) and therefore trusts the host's DNS and TLS. See [[Security Model]].
+
+### JSON output
+
+With `--json`, the verifier prints a single JSON object instead of the human `[+]/[-]/[~]` lines, and exits `0` when the badge is valid and non-zero otherwise — convenient for CI gates and services. Common fields: `valid` (bool), `ob_version` (`"2"`/`"3"`), `recipient`, and `reason` (`null` on success, a message on failure). OB2 adds `trusted` (operator key vs badge-embedded) and `status` (`VALID`/`EXPIRED`/`REVOKED`/…); OB3 adds `issuer`, `achievement`, `issued_on`, `expires`, `evidence`, and `issuer_did` when the key came from `--resolve-did`.
+
+```sh
+$ openbadges-verifier -i badge.svg -r recipient@example.com -V 3 -k verify.pem --json
+{"ob_version": "3", "recipient": "recipient@example.com", "trusted": true, "valid": true, "reason": null, "issuer": "Issuer", "achievement": "A", "issued_on": "2026-01-01T00:00:00+00:00", "expires": null, "evidence": null}
+```
 
 ## openbadges-publish
 


### PR DESCRIPTION
openbadges-verifier gains a --json flag that emits a single JSON result
object instead of the human [+]/[-]/[~] lines, and exits 0 when the badge
is valid / non-zero otherwise — so CI gates and services can consume the
verdict without scraping stdout.

The result carries valid, ob_version, recipient and reason, plus
version-specific fields: OB2 adds trusted and status; OB3 adds issuer,
achievement, issued_on, expires, evidence, and issuer_did (when resolved
via --resolve-did). Failure cases (missing file, extraction error, bad
signature, recipient mismatch, missing key) all produce a JSON object too.
The default human output and its historical exit codes are unchanged.

Fixes #106

VERIFIED: flake8, mypy, and pytest (481 passed — +7 new JSON tests, and the
38 existing CLI smoke tests still green, confirming the human path is byte-
for-byte unchanged); CLI-Reference documents --json (docs gate passes).
