### PR TITLE
EUDI track hardening: openvc-core >=1.13 pin + dedicated CI drift job (#172)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,56 @@ jobs:
       - name: Test (pytest + coverage)
         run: pytest --cov=openbadgeslib --cov-report=term-missing
 
+  eudi:
+    # Hardening for the optional [eudi] SD-JWT VC track, which delegates its
+    # crypto to openvc-core (a separate repo). The main `test` job installs the
+    # extra alongside everything else; this job adds two guarantees it can't:
+    #   * isolation — install ONLY [dev,eudi] (no ldp/pyld), proving the track
+    #     stands on openvc-core alone;
+    #   * version-drift — run against both the pinned floor and the latest
+    #     openvc-core release, so an upstream bump fails here, not in a user's
+    #     install.
+    # Not a publish gate: the `latest` leg is an early warning
+    # (continue-on-error); the `floor` leg — the version we ship against — is
+    # authoritative. See #172.
+    name: eudi extra (openvc-core ${{ matrix.openvc }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        openvc: [floor, latest]
+    continue-on-error: ${{ matrix.openvc == 'latest' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Install the package with only the [eudi] extra
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,eudi]"
+
+      - name: Pin openvc-core to the declared floor
+        if: matrix.openvc == 'floor'
+        # Keep 1.13.* in sync with the [eudi] pin in pyproject.toml.
+        run: pip install "openvc-core==1.13.*"
+
+      - name: Take the latest openvc-core release
+        if: matrix.openvc == 'latest'
+        run: pip install -U "openvc-core<2"
+
+      - name: Record the resolved openvc-core version
+        run: pip show openvc-core | grep '^Version:'
+
+      - name: Test the EUDI SD-JWT VC track (isolated) and type-check it
+        run: |
+          pytest tests/test_ob3_eudi_sd_jwt.py -v
+          mypy openbadgeslib/ob3/eudi.py
+
   publish:
     name: Publish to PyPI
     # Fires when a vX.Y.Z tag is pushed, when a GitHub Release is published, or

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ ldp = [
 # the suite is tested against, ceiling at the next major.
 # See openbadgeslib/ob3/eudi.py.
 eudi = [
-    "openvc-core>=1.8,<2",
+    "openvc-core>=1.13,<2",
 ]
 dev = [
     "pytest>=8.0",


### PR DESCRIPTION
Advances #172 (EUDI track hardening). Follows the openvc-core 1.8→1.13.1 update.

## Changes
- **`build(eudi)`** — bump the `[eudi]` pin `openvc-core>=1.8` → `>=1.13` after the SD-JWT VC suite passed against 1.13.1 (12/12, mypy clean). openvc-core is 1.x Production/Stable; `>=1.13,<2` is the SemVer contract. No code change — `eudi.py` uses only 1.8-era symbols, so the bump is a "what we test against" statement.
- **`ci(eudi)`** — new dedicated `eudi` job in `ci.yml`: installs **only** `.[dev,eudi]` (no `ldp`/pyld → proves the track stands on openvc-core alone), runs the eudi tests + `mypy openbadgeslib/ob3/eudi.py`, across a **`floor` vs `latest`** openvc-core matrix. The `floor` leg is authoritative; `latest` is `continue-on-error` (early warning when openvc-core ships a release). Not wired into `publish`'s `needs:` — the optional extra never gates a core release.

Validated locally in a clean venv: isolated `.[dev,eudi]` install (no pyld present) → **12/12** + mypy clean.

No Changelog entry: both commits are gitlint *silent* types (`build`/`ci`); the `build(eudi)` note is drafted at release time from the commit title.

## Not in this PR (tracked separately)
- #179 — end-to-end OpenID4VP `ldp_vc` presentation walkthrough (unlocked by openvc-core 1.12)
- #171 — `ecdsa-sd-2023` verify-only go/no-go (delegation now viable — brief posted on the issue)
- HAIP 1.1 watch (expected 2026-12-21)
