### PR TITLE
feat(ldp): verify ecdsa-sd-2023 selective-disclosure proofs (#171)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -4,6 +4,24 @@ OpenBadgesLib - Changelog
 Newest first. Dates are ISO 8601 (YYYY-MM-DD).
 
 
+* v3.11.0 - unreleased
+
+  - feat(ldp): verify OpenBadges 3.0 credentials secured with the
+    **ecdsa-sd-2023** (selective disclosure) Data Integrity cryptosuite — the
+    verify-only slice of #171. A derived proof is verified by delegating the
+    large, security-sensitive selective-disclosure crypto (CBOR base/derived
+    proofs, HMAC label maps, per-statement P-256 signatures) to openvc-core's
+    audited `EcdsaSdProofSuite`; openbadgeslib keeps the OB3 model, the trust
+    binding (proof `verificationMethod` ↔ credential issuer) and the lifecycle
+    checks around it, and hands the delegate its pinned OB3 `@context`
+    allowlist so canonicalization stays fail-closed and never touches the
+    network. It plugs into the `_CRYPTOSUITES` registry beside eddsa-rdfc-2022,
+    so `OB3LdpVerifier` accepts both transparently. Verify-only for Displayer
+    parity (1EdTech OB3 certification requires verifying both suites); issuing
+    ecdsa-sd-2023 stays out of scope. Needs the new `[ldp-sd]` extra
+    (`openvc-core[data-integrity]`, self-contained — pulls its own pyld); a
+    missing extra fails closed with an actionable install hint. (Closes #171)
+
 * v3.10.0 - 2026-07-08
 
   - feat(publish): `openbadges-publish -V 3 --check-live` completes #164. After

--- a/openbadgeslib/ob3/contexts/__init__.py
+++ b/openbadgeslib/ob3/contexts/__init__.py
@@ -112,6 +112,17 @@ def load_context(url: str) -> dict[str, Any]:
     return document
 
 
+def bundled_contexts() -> Dict[str, dict[str, Any]]:
+    """The whole pinned allowlist as a ``{url: context document}`` map.
+
+    For handing openbadgeslib's fail-closed context set to another Data
+    Integrity engine that takes its own ``extra_contexts`` (e.g. openvc-core's
+    verifier for the delegated ecdsa-sd-2023 path), so it canonicalizes against
+    exactly these pinned documents and never the network.
+    """
+    return {url: load_context(url) for url in _URL_TO_RESOURCE}
+
+
 def document_loader(
         extra_contexts: Optional[Mapping[str, dict[str, Any]]] = None,
 ) -> Callable[[str, Any], dict[str, Any]]:

--- a/openbadgeslib/ob3/ldp.py
+++ b/openbadgeslib/ob3/ldp.py
@@ -23,8 +23,17 @@
 # OpenBadges 3.0 credentials secured with a W3C Data Integrity proof (the
 # OB 3.0 "Linked Data Proof" format) — issuance and verification, the
 # counterpart of the JWT-VC signer/verifier for the other proof format the
-# spec allows. Supported cryptosuite: eddsa-rdfc-2022 (W3C Recommendation
-# vc-di-eddsa).
+# spec allows.
+#
+# Cryptosuites: eddsa-rdfc-2022 (W3C Recommendation vc-di-eddsa) is issued and
+# verified natively here. ecdsa-sd-2023 (selective disclosure, vc-di-ecdsa) is
+# VERIFY-only and delegated to openvc-core's audited EcdsaSdProofSuite — the
+# large, security-sensitive selective-disclosure machinery (CBOR base/derived
+# proofs, HMAC label maps, per-statement signatures) lives there rather than
+# duplicated here; it needs the optional [ldp-sd] extra. openbadgeslib keeps the
+# OB3 model, trust binding and lifecycle checks around it. Issuing ecdsa-sd-2023
+# stays out of scope until there is named demand (verify-only for Displayer
+# parity per the 1EdTech certification requirement).
 #
 # The algorithm, shared by both directions: RDFC-1.0-canonicalize the
 # document without its proof and the proof options without proofValue (with
@@ -49,7 +58,7 @@ from .. import baking
 from ..errors import ErrorSigningFile
 from ..keys import KeyType, detect_key_type, key_to_pem
 from ..util import __version__
-from .contexts import UnknownContextError, document_loader
+from .contexts import UnknownContextError, bundled_contexts, document_loader
 from .credential import OpenBadgeCredential, _iso, _parse_iso
 from .did import (_b58btc_decode, _b58btc_encode, _public_key_to_pem,
                   did_key_from_pem, resolve_verification_method)
@@ -226,11 +235,86 @@ def _verify_eddsa_rdfc_2022(document: dict[str, Any], proof: dict[str, Any], pub
             "could not verify the Data Integrity proof: %s" % exc) from exc
 
 
-#: Registry of supported cryptosuites. ecdsa-sd-2023 (selective disclosure)
-#: is deliberately absent — deferred until there is real interop demand; an
-#: unknown suite fails closed naming the supported ones.
+def _require_openvc_ecdsa_sd() -> tuple[Any, Any]:
+    """Import openvc-core's ecdsa-sd-2023 suite (and its error root), or fail
+    with an actionable hint. The selective-disclosure crypto is delegated, not
+    reimplemented — see the module docstring."""
+    try:
+        from openvc.proof.ecdsa_sd import EcdsaSdProofSuite
+        from openvc.proof.errors import ProofError
+    except ImportError as exc:
+        raise OB3VerificationError(
+            "verifying ecdsa-sd-2023 (selective-disclosure) Data Integrity "
+            "proofs requires the optional openvc-core dependency; install it "
+            "with: pip install openbadgeslib[ldp-sd]") from exc
+    return EcdsaSdProofSuite, ProofError
+
+
+def _p256_pem_to_jwk(pubkey_pem: bytes) -> dict[str, str]:
+    """A NIST P-256 public-key PEM as the JWK openvc-core's ecdsa-sd-2023
+    verifier takes. Rejects any non-P-256 key (the cryptosuite is P-256 only)
+    before it reaches the suite."""
+    import base64
+
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.hazmat.primitives.serialization import load_pem_public_key
+    try:
+        pub = load_pem_public_key(pubkey_pem)
+    except Exception as exc:
+        raise OB3VerificationError(
+            "unusable verification key: %s" % exc) from exc
+    if not (isinstance(pub, ec.EllipticCurvePublicKey)
+            and isinstance(pub.curve, ec.SECP256R1)):
+        raise OB3VerificationError(
+            "ecdsa-sd-2023 requires a NIST P-256 verification key")
+    numbers = pub.public_numbers()
+
+    def _b64u(value: int) -> str:
+        return base64.urlsafe_b64encode(
+            value.to_bytes(32, 'big')).rstrip(b'=').decode('ascii')
+
+    return {'kty': 'EC', 'crv': 'P-256',
+            'x': _b64u(numbers.x), 'y': _b64u(numbers.y)}
+
+
+def _verify_ecdsa_sd_2023(document: dict[str, Any], proof: dict[str, Any],
+                          pubkey_pem: bytes, loader: Any) -> None:
+    """Verify one ecdsa-sd-2023 derived proof by delegating to openvc-core.
+
+    openvc-core owns the whole selective-disclosure verification — its own RDF
+    canonicalization plus the base and per-statement P-256 signatures;
+    openbadgeslib only resolves/pins the key and feeds its pinned OB3 @context
+    allowlist, so canonicalization is fail-closed and never touches the network.
+    *loader* (openbadgeslib's own pyld loader) is unused here — the delegate
+    canonicalizes with its engine.
+    """
+    del loader
+    EcdsaSdProofSuite, ProofError = _require_openvc_ecdsa_sd()
+    public_key_jwk = _p256_pem_to_jwk(pubkey_pem)
+    try:
+        EcdsaSdProofSuite().verify(
+            document,
+            public_key_jwk=public_key_jwk,
+            expected_proof_purpose=proof.get('proofPurpose'),
+            extra_contexts=bundled_contexts(),
+        )
+    except ProofError as exc:
+        raise OB3VerificationError(
+            "Invalid ecdsa-sd-2023 Data Integrity proof: %s" % exc) from exc
+    except OB3VerificationError:
+        raise
+    except Exception as exc:
+        raise OB3VerificationError(
+            "could not verify the ecdsa-sd-2023 proof: %s" % exc) from exc
+
+
+#: Registry of supported cryptosuites -> verify callback. eddsa-rdfc-2022 is
+#: verified natively; ecdsa-sd-2023 (selective disclosure) is VERIFY-only and
+#: delegated to openvc-core (needs the [ldp-sd] extra — see the module
+#: docstring). An unknown suite fails closed naming the supported ones.
 _CRYPTOSUITES: Dict[str, Callable[[dict[str, Any], dict[str, Any], bytes, Any], None]] = {
     'eddsa-rdfc-2022': _verify_eddsa_rdfc_2022,
+    'ecdsa-sd-2023': _verify_ecdsa_sd_2023,
 }
 
 
@@ -336,7 +420,11 @@ def add_data_integrity_proof(
 
 class OB3LdpVerifier:
     """Verifies OpenBadges 3.0 credentials secured with a Data Integrity
-    (Linked Data Proof) embedded proof — cryptosuite eddsa-rdfc-2022.
+    (Linked Data Proof) embedded proof — cryptosuites eddsa-rdfc-2022 and,
+    for selective-disclosure credentials, ecdsa-sd-2023 (verify delegated to
+    openvc-core). A derived ecdsa-sd-2023 proof reveals only the mandatory plus
+    holder-disclosed statements, so the reconstructed credential reflects just
+    what the holder chose to show.
 
     Mirrors :class:`OB3Verifier` (the JWT-VC verifier) in API and trust
     model, for the other proof format OB 3.0 allows:
@@ -348,8 +436,9 @@ class OB3LdpVerifier:
       proves internal consistency, not issuer identity — so callers should
       treat it as untrusted unless the DID itself is trusted.
 
-    Requires the optional ``[ldp]`` extra (``pip install openbadgeslib[ldp]``)
-    at verification time; constructing the verifier works without it.
+    eddsa-rdfc-2022 needs the optional ``[ldp]`` extra (pyld); ecdsa-sd-2023
+    needs ``[ldp-sd]`` (openvc-core). The required extra is imported lazily at
+    verification time; constructing the verifier works without either.
     """
 
     def __init__(self, pubkey_pem: Any = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,16 @@ ldp = [
 eudi = [
     "openvc-core>=1.13,<2",
 ]
+# ecdsa-sd-2023 (selective disclosure) VERIFY for the OB 3.0 Data Integrity
+# track: credentials secured with the ecdsa-sd-2023 cryptosuite are verified by
+# delegating the large, security-sensitive selective-disclosure crypto to
+# openvc-core's audited EcdsaSdProofSuite — openbadgeslib keeps the OB3 model,
+# trust binding and lifecycle checks. Pulls openvc-core with its RDF
+# canonicalization (pyld). Native eddsa-rdfc-2022 stays under [ldp]; issuance of
+# ecdsa-sd-2023 is out of scope. See openbadgeslib/ob3/ldp.py.
+ldp-sd = [
+    "openvc-core[data-integrity]>=1.13,<2",
+]
 dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",

--- a/tests/test_ob3_ldp.py
+++ b/tests/test_ob3_ldp.py
@@ -179,10 +179,14 @@ class TestProofValidation:
         return copy.deepcopy(ldp_signed_vc)
 
     def test_unknown_cryptosuite_fails_closed(self, ldp_signed_vc):
+        # A real Data Integrity suite openbadgeslib does not implement (only the
+        # whole-document eddsa-rdfc-2022 and selective-disclosure ecdsa-sd-2023
+        # are supported); the failure names the supported set.
         doc = self._base(ldp_signed_vc)
-        doc['proof']['cryptosuite'] = 'ecdsa-sd-2023'
+        doc['proof']['cryptosuite'] = 'ecdsa-rdfc-2019'
         with pytest.raises(OB3VerificationError,
-                           match='supported cryptosuites: eddsa-rdfc-2022'):
+                           match='supported cryptosuites: ecdsa-sd-2023, '
+                                 'eddsa-rdfc-2022'):
             OB3LdpVerifier().verify(doc)
 
     def test_wrong_proof_type_fails_closed(self, ldp_signed_vc):

--- a/tests/test_ob3_ldp_ecdsa_sd.py
+++ b/tests/test_ob3_ldp_ecdsa_sd.py
@@ -1,0 +1,142 @@
+"""Tests for the delegated ecdsa-sd-2023 (selective disclosure) verify path —
+ob3.ldp.
+
+openbadgeslib only VERIFIES ecdsa-sd-2023, delegating the crypto to
+openvc-core. These tests use openvc-core to issue a base proof and derive a
+holder presentation, then verify it through OB3LdpVerifier / the low-level
+entry, so they exercise openbadgeslib's wiring (P-256 key -> JWK, the pinned
+OB3 @context set handed to the delegate, exception mapping, the cryptosuite
+registry) rather than re-testing openvc's crypto internals. They need the
+[ldp-sd] extra (openvc-core + pyld) and skip without it; the "extra absent"
+test at the bottom runs always.
+"""
+import copy
+import sys
+
+import pytest
+
+from openbadgeslib.ob3 import OB3VerificationError
+from openbadgeslib.ob3.ldp import (
+    OB3LdpVerifier,
+    _verify_ecdsa_sd_2023,
+    verify_data_integrity_proof,
+)
+
+# Core fields always revealed; credentialSchema is left non-mandatory so it can
+# be disclosed selectively (exercising the per-statement signatures) or withheld
+# (exercising a genuine selective-disclosure omission).
+MANDATORY = ['/id', '/type', '/name', '/issuer', '/validFrom',
+             '/credentialSubject']
+
+
+def _p256_pem_pair():
+    from cryptography.hazmat.primitives import serialization as ser
+    from cryptography.hazmat.primitives.asymmetric import ec
+    priv = ec.generate_private_key(ec.SECP256R1())
+    return (
+        priv.private_bytes(ser.Encoding.PEM, ser.PrivateFormat.PKCS8,
+                           ser.NoEncryption()),
+        priv.public_key().public_bytes(
+            ser.Encoding.PEM, ser.PublicFormat.SubjectPublicKeyInfo),
+    )
+
+
+def _issue_and_derive(ob3_credential, *, selective):
+    """openvc issues an ecdsa-sd-2023 base proof over a did:key-issuer OB3
+    credential, then derives a presentation revealing MANDATORY + *selective*.
+    Returns (derived_doc, p256_pub_pem, issuer_did)."""
+    from openvc.keys import P256SigningKey
+    from openvc.proof.ecdsa_sd import EcdsaSdProofSuite
+
+    from openbadgeslib.ob3.contexts import bundled_contexts
+    from openbadgeslib.ob3.did import did_key_from_pem
+
+    priv_pem, pub_pem = _p256_pem_pair()
+    did = did_key_from_pem(pub_pem)
+    vm = '%s#%s' % (did, did[len('did:key:'):])
+
+    doc = ob3_credential.to_vc()
+    doc['issuer'] = {'id': did, 'type': ['Profile'], 'name': 'Test Issuer',
+                     'url': 'https://example.com'}
+
+    # openvc canonicalizes with its own engine, which does not bundle the OB3
+    # (imsglobal) contexts — hand it openbadgeslib's pinned set, exactly as the
+    # verify path does. Otherwise issuance fails to normalize the OB3 document.
+    ctx = bundled_contexts()
+    suite = EcdsaSdProofSuite()
+    base = suite.add_base_proof(
+        doc, signing_key=P256SigningKey.from_pem(priv_pem, kid=vm),
+        verification_method=vm, mandatory_pointers=MANDATORY,
+        extra_contexts=ctx)
+    derived = suite.derive_proof(base, selective_pointers=selective,
+                                 extra_contexts=ctx)
+    return derived, pub_pem, did
+
+
+@pytest.fixture(scope='session')
+def sd_credential(ob3_credential):
+    """A holder presentation revealing the core fields + credentialSchema."""
+    pytest.importorskip('openvc')
+    pytest.importorskip('pyld')
+    return _issue_and_derive(ob3_credential, selective=['/credentialSchema'])
+
+
+class TestEcdsaSdVerify:
+    def test_pinned_key_roundtrip(self, sd_credential):
+        derived, pub_pem, _ = sd_credential
+        cred = OB3LdpVerifier(pubkey_pem=pub_pem).verify(derived)
+        assert cred.achievement.name == 'Test Achievement'
+
+    def test_low_level_entry_verifies(self, sd_credential):
+        derived, pub_pem, _ = sd_credential
+        verify_data_integrity_proof(derived, pub_pem)  # no raise == verified
+
+    def test_did_key_resolution_roundtrip(self, sd_credential):
+        # No pinned key: the P-256 did:key verificationMethod is resolved, and
+        # (issuer == that did:key) authorizes it.
+        derived, _, did = sd_credential
+        cred = OB3LdpVerifier().verify(derived)
+        assert cred.issuer.id == did
+
+    def test_tampered_disclosed_field_rejected(self, sd_credential):
+        derived, pub_pem, _ = sd_credential
+        tampered = copy.deepcopy(derived)
+        tampered['name'] = 'Bachelor of Villainy'
+        with pytest.raises(OB3VerificationError):
+            OB3LdpVerifier(pubkey_pem=pub_pem).verify(tampered)
+
+    def test_wrong_key_rejected(self, sd_credential):
+        derived, _, _ = sd_credential
+        _, other_pub = _p256_pem_pair()
+        with pytest.raises(OB3VerificationError):
+            OB3LdpVerifier(pubkey_pem=other_pub).verify(derived)
+
+    def test_ed25519_key_rejected(self, sd_credential, ed25519_keypair):
+        # ecdsa-sd-2023 is P-256 only; an Ed25519 key fails before the delegate.
+        derived, _, _ = sd_credential
+        _, ed_pub = ed25519_keypair
+        with pytest.raises(OB3VerificationError, match='P-256'):
+            OB3LdpVerifier(pubkey_pem=ed_pub).verify(derived)
+
+    def test_selective_omission(self, ob3_credential):
+        # Withhold credentialSchema entirely: still verifies, and the field is
+        # absent from the presentation the verifier sees.
+        derived, pub_pem, _ = _issue_and_derive(ob3_credential, selective=[])
+        assert 'credentialSchema' not in derived
+        OB3LdpVerifier(pubkey_pem=pub_pem).verify(derived)
+
+    def test_registered_in_cryptosuites(self):
+        from openbadgeslib.ob3.ldp import _CRYPTOSUITES
+        assert 'ecdsa-sd-2023' in _CRYPTOSUITES
+
+
+# ── behaviour without the [ldp-sd] extra (runs with or without openvc) ───────
+
+def test_missing_openvc_yields_actionable_error(monkeypatch):
+    # Null the submodules too — nulling only the top package is ignored when the
+    # submodules are already cached in sys.modules.
+    for name in ('openvc', 'openvc.proof.ecdsa_sd', 'openvc.proof.errors'):
+        monkeypatch.setitem(sys.modules, name, None)
+    with pytest.raises(OB3VerificationError, match=r'ldp-sd'):
+        _verify_ecdsa_sd_2023({}, {'proofPurpose': 'assertionMethod'},
+                              b'irrelevant', None)

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -49,6 +49,18 @@ Nothing else needs it: the default proof format stays JWT-VC, and without the
 extra the rest of the library works unchanged (attempting to sign or verify a
 Data Integrity credential reports the missing extra with an install hint).
 
+```sh
+pip install "openbadgeslib[ldp-sd]"
+```
+
+The `[ldp-sd]` extra adds **verify** support for the selective-disclosure
+cryptosuite `ecdsa-sd-2023` (W3C vc-di-ecdsa), delegating the crypto to
+[`openvc-core`](https://pypi.org/project/openvc-core/) — a Displayer must verify
+both Data Integrity suites to conform to the 1EdTech OB 3.0 certification. It is
+self-contained (pulls its own JSON-LD processor), so it works with or without
+`[ldp]`; **issuing** `ecdsa-sd-2023` is out of scope. Without the extra,
+verifying such a credential fails closed with an install hint.
+
 ## Development install
 
 Clone the repository and install in editable mode together with the test and lint dependencies:


### PR DESCRIPTION
Closes #171 — the verify-only slice, delegated to openvc-core (per the go/no-go on the issue).

## What
Verify OB 3.0 credentials secured with the **ecdsa-sd-2023** selective-disclosure Data Integrity cryptosuite. The large, security-sensitive crypto is delegated to openvc-core's audited `EcdsaSdProofSuite`; openbadgeslib keeps the OB3 model, the trust binding (proof `verificationMethod` ↔ credential issuer) and the lifecycle checks, and feeds the delegate its pinned OB3 `@context` set so canonicalization stays fail-closed and never touches the network. Plugged into the `_CRYPTOSUITES` registry beside eddsa-rdfc-2022, so `OB3LdpVerifier` accepts both transparently.

New `[ldp-sd]` extra (`openvc-core[data-integrity]`) — self-contained (pulls its own pyld, works without `[ldp]`). **~107 lines of wiring** vs the **~1000 of native crypto** avoided. Issuing ecdsa-sd-2023 stays out of scope.

## Verification
- New suite `tests/test_ob3_ldp_ecdsa_sd.py` (9): issue+derive via openvc → verify via openbadgeslib — pinned-key + did:key round-trips, tamper, wrong key, Ed25519 guard, selective omission, missing-extra actionable error.
- Full suite: **1076 passed**, coverage **93.03%**. flake8 + mypy clean.
- `[ldp-sd]` isolation validated in a clean venv (without `[ldp]`): 9/9.

Ships as `feat(ldp)` in the v3.11.0 Changelog (unreleased).
