### PR TITLE
docs(ob3): OpenID4VP ldp_vc presentation walkthrough + example (#179)

### DIFF
--- a/examples/ob3_openid4vp_presentation.py
+++ b/examples/ob3_openid4vp_presentation.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Present an OpenBadges 3.0 Data Integrity badge over OpenID4VP, and verify it.
+
+Three roles, one clean split of responsibilities:
+
+  * ISSUER   — openbadgeslib issues the badge as an OB 3.0 Data Integrity
+               credential (eddsa-rdfc-2022). Issuing credentials is this
+               library's job.
+  * HOLDER   — a wallet wraps the badge in a W3C Verifiable Presentation and
+               signs a Data Integrity ``authentication`` proof bound to the
+               verifier's request (challenge = nonce, domain = client_id).
+  * VERIFIER — a relying party verifies the OpenID4VP ``vp_token`` against its
+               DCQL query and that request binding.
+
+The wallet-exchange rail (building the VP, ``verify_vp_token``) lives in
+openvc-core, not here: openbadgeslib mints the credential, openvc-core carries
+it over OpenID4VP 1.0. That is the delegation boundary the Certification
+Cookbook describes. Needs the [ldp-sd] extra (openvc-core + a JSON-LD
+processor):
+
+    pip install "openbadgeslib[ldp-sd]"
+    python examples/ob3_openid4vp_presentation.py
+"""
+
+from datetime import datetime, timezone
+
+
+def main() -> None:
+    try:
+        import pyld  # noqa: F401
+        from openvc.keys import Ed25519SigningKey
+        from openvc.openid4vp import verify_vp_token
+        from openvc.proof.data_integrity import DataIntegrityProofSuite
+    except ImportError:
+        print('This example needs the [ldp-sd] extra (openvc-core + pyld): '
+              'pip install "openbadgeslib[ldp-sd]". Skipping.')
+        return
+
+    from openbadgeslib.keys import KeyFactory, KeyType
+    from openbadgeslib.ob3 import (Achievement, Issuer, OB3LdpSigner,
+                                   OpenBadgeCredential)
+    from openbadgeslib.ob3.contexts import bundled_contexts
+    from openbadgeslib.ob3.did import did_key_from_pem
+
+    # openvc-core canonicalizes with its own engine, which does not bundle the
+    # OB 3.0 (imsglobal) @context — hand it openbadgeslib's pinned, fail-closed
+    # set so the badge inside the VP resolves without touching the network.
+    ob3_contexts = bundled_contexts()
+
+    def did_and_vm(pub_pem: bytes) -> tuple[str, str]:
+        did = did_key_from_pem(pub_pem)
+        return did, '%s#%s' % (did, did[len('did:key:'):])
+
+    # ── HOLDER: a wallet key and its did:key identity ────────────────────────
+    holder_priv, holder_pub = KeyFactory(KeyType.ED25519).generate_keypair()
+    holder_did, holder_vm = did_and_vm(holder_pub)
+
+    # ── ISSUER (openbadgeslib): issue the badge TO the holder ────────────────
+    issuer_priv, issuer_pub = KeyFactory(KeyType.ED25519).generate_keypair()
+    issuer_did, issuer_vm = did_and_vm(issuer_pub)
+    badge = OpenBadgeCredential(
+        issuer=Issuer(id=issuer_did, name='Example University'),
+        recipient_id=holder_did,                  # subject == the wallet holder
+        achievement=Achievement(
+            id='https://issuer.example/badges/python-101', name='Python 101',
+            description='Completed the introductory Python course.',
+            criteria_narrative='Passed all assignments and the final project.'),
+        issuance_date=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    secured_badge = OB3LdpSigner(issuer_priv, issuer_vm).sign(badge)
+    print('Issuer minted an OB 3.0 Data Integrity badge "%s" for the holder.'
+          % secured_badge['credentialSubject']['achievement']['name'])
+
+    # ── VERIFIER: the OpenID4VP request the holder is answering ──────────────
+    nonce = 'n-0S6_WzA2Mj'                         # per-session, from the request
+    client_id = 'x509_san_dns:verifier.example'    # the full, prefixed Client ID
+    dcql_query = {'credentials': [{'id': 'c1', 'format': 'ldp_vc'}]}
+
+    # ── HOLDER (openvc-core): wrap the badge in a VP, bind it to the request ──
+    presentation = {
+        '@context': ['https://www.w3.org/ns/credentials/v2'],
+        'type': ['VerifiablePresentation'],
+        'holder': holder_did,
+        'verifiableCredential': [secured_badge],
+    }
+    holder_key = Ed25519SigningKey.from_pem(holder_priv, kid=holder_vm)
+    vp = DataIntegrityProofSuite().add_proof(
+        presentation, signing_key=holder_key, verification_method=holder_vm,
+        proof_purpose='authentication', challenge=nonce, domain=client_id,
+        extra_contexts=ob3_contexts)
+    print('Holder presented it as an ldp_vc VP (authentication proof; '
+          'challenge=nonce, domain=client_id).')
+
+    # ── VERIFIER (openvc-core): verify the vp_token, bound to the request ────
+    result = verify_vp_token(
+        {'c1': [vp]}, dcql_query=dcql_query, nonce=nonce, client_id=client_id,
+        extra_contexts=ob3_contexts,
+        require_holder_binding=True)               # subject must equal the holder
+    (p,) = result.presentations
+    print('Verifier accepted the vp_token: format=%s, authenticated holder=%s'
+          % (p.format, p.holder))
+    print('  embedded badge issuer=%s' % p.credentials[0].issuer)
+    print('  subject == authenticated holder: %s'
+          % (p.credentials[0].subject == p.holder))
+
+    assert p.format == 'ldp_vc'
+    assert p.holder == holder_did
+    assert p.credentials[0].subject == holder_did          # recipient-bound
+
+
+if __name__ == '__main__':
+    main()

--- a/wiki/Certification-Cookbook.md
+++ b/wiki/Certification-Cookbook.md
@@ -32,7 +32,7 @@ The same idea applies to strict OB 2.0: the opt-in suite exercises both the **Ho
 ## What is deliberately *not* here
 
 - **Paid 1EdTech membership / the certification portal** — a business decision, not a technical gap. Everything needed to *pass* the tests is above.
-- **Building an OID4VCI/OID4VP issuance rail** — that belongs in `openvc-core`, per the project's delegation pattern; this library issues the credentials, not the wallet-exchange protocol.
+- **Building an OID4VCI/OID4VP issuance rail** — the wallet-exchange *protocol* belongs in `openvc-core`, per the project's delegation pattern; this library issues the credentials, not the protocol. For an end-to-end **presentation** demo — issue a Data Integrity badge here → present it as an `ldp_vc` VP → verify via openvc-core — see the "Presenting a Data Integrity badge over OpenID4VP" section of [[Python API OB3]] and `examples/ob3_openid4vp_presentation.py`.
 
 ## See also
 

--- a/wiki/Python-API-OB3.md
+++ b/wiki/Python-API-OB3.md
@@ -178,9 +178,11 @@ So `expected_recipient='recipient@example.com'` and `expected_recipient='mailto:
 ## Verifying Data Integrity (LDP) credentials — `OB3LdpVerifier`
 
 OB 3.0 allows a second proof format besides VC-JWT: a JSON-LD credential with
-an embedded **W3C Data Integrity proof**. `OB3LdpVerifier` verifies those
-(cryptosuite `eddsa-rdfc-2022`; requires the `[ldp]` extra — see
-[[Installation]]) with the same API and trust model as `OB3Verifier`:
+an embedded **W3C Data Integrity proof**. `OB3LdpVerifier` verifies those with
+the same API and trust model as `OB3Verifier`, across two cryptosuites:
+`eddsa-rdfc-2022` (whole-document; the `[ldp]` extra) and, for selective
+disclosure, `ecdsa-sd-2023` (verify delegated to `openvc-core`; the `[ldp-sd]`
+extra) — see [[Installation]]:
 
 ```python
 from openbadgeslib.ob3 import OB3LdpVerifier
@@ -210,7 +212,9 @@ test vectors) the crypto core is exposed as
 which checks only the proof itself. `@context` documents are **never fetched
 from the network** — canonicalization uses the contexts bundled with the
 library (see [[Security Model]]); `extra_contexts` extends that allowlist per
-call. An unsupported cryptosuite (e.g. `ecdsa-sd-2023`) fails closed naming
+call. `ecdsa-sd-2023` (selective disclosure) is verified by delegating to
+`openvc-core` (the `[ldp-sd]` extra); a cryptosuite the library supports
+neither natively nor by delegation (e.g. `ecdsa-rdfc-2019`) fails closed naming
 the supported ones.
 
 ## Issuing Data Integrity (LDP) credentials — `OB3LdpSigner`
@@ -330,6 +334,36 @@ assert result.key_bound
 ```
 
 The OID4VCI / OID4VP wallet-exchange protocol itself lives in `openvc-core`, not here: this module maps a badge to and from SD-JWT VC claims and runs the issuer/holder crypto through it.
+
+## Presenting a Data Integrity badge over OpenID4VP (`ldp_vc`)
+
+A wallet presents an OB 3.0 **Data Integrity** badge to a relying party as an OpenID4VP 1.0 `ldp_vc` credential: a W3C **Verifiable Presentation** wrapping the badge, secured by a holder **`authentication`** proof bound to the request (`challenge` = the request `nonce`, `domain` = the full, prefixed `client_id`). Building and verifying that presentation is the wallet-exchange rail — it lives in [`openvc-core`](https://pypi.org/project/openvc-core/), not here: openbadgeslib issues the badge, openvc-core carries it. Needs the `[ldp-sd]` extra (see [[Installation]]).
+
+```python
+from openvc.proof.data_integrity import DataIntegrityProofSuite  # eddsa-rdfc-2022
+from openvc.openid4vp import verify_vp_token
+from openbadgeslib.ob3.contexts import bundled_contexts
+
+# openbadgeslib issued `secured_badge` (an OB3LdpSigner document). The holder
+# wraps it in a VP and signs an `authentication` proof bound to the request:
+vp = DataIntegrityProofSuite().add_proof(
+    {'@context': ['https://www.w3.org/ns/credentials/v2'],
+     'type': ['VerifiablePresentation'], 'holder': holder_did,
+     'verifiableCredential': [secured_badge]},
+    signing_key=holder_key, verification_method=holder_vm,
+    proof_purpose='authentication', challenge=nonce, domain=client_id,
+    extra_contexts=bundled_contexts())         # OB3 @context, fail-closed
+
+# The verifier checks the vp_token against its DCQL query and request binding:
+result = verify_vp_token(
+    {'c1': [vp]}, dcql_query={'credentials': [{'id': 'c1', 'format': 'ldp_vc'}]},
+    nonce=nonce, client_id=client_id, extra_contexts=bundled_contexts(),
+    require_holder_binding=True)                # embedded subject must be the holder
+(p,) = result.presentations
+assert p.format == 'ldp_vc' and p.holder == holder_did
+```
+
+Pass openbadgeslib's `bundled_contexts()` as `extra_contexts` so openvc-core canonicalizes the badge against the same pinned OB 3.0 `@context` set, never the network. The reported `holder` is the **authenticated** signer (never a self-asserted `holder` field); `require_holder_binding=True` additionally demands every embedded credential's `credentialSubject.id` equal that holder. Runnable end to end in [`examples/ob3_openid4vp_presentation.py`](https://github.com/luisgf/openbadgeslib/blob/master/examples/ob3_openid4vp_presentation.py).
 
 ## Errors
 


### PR DESCRIPTION
Closes #179 — the end-to-end OpenID4VP `ldp_vc` presentation walkthrough (docs/example; unlocked by openvc-core 1.12).

## What
A runnable example + wiki walkthrough showing a Data Integrity badge presented over OpenID4VP 1.0:
- **openbadgeslib** issues the OB 3.0 badge.
- **openvc-core** (the wallet-exchange rail) builds the `ldp_vc` VP with a holder `authentication` proof (`challenge` = nonce, `domain` = client_id) and verifies the `vp_token` via `verify_vp_token`, with `require_holder_binding`.
- openbadgeslib's pinned OB3 `@context` set is fed to openvc-core via `extra_contexts` — canonicalization stays fail-closed, never the network.

## Changes
- `examples/ob3_openid4vp_presentation.py` — CI-guarded by `test_examples.py`; skips cleanly without `[ldp-sd]`.
- wiki `Python-API-OB3` — new "Presenting a Data Integrity badge over OpenID4VP" section; cross-linked from the Certification Cookbook (#168).
- Corrects a doc-drift from #171: `ecdsa-sd-2023` is now a supported (delegated) verify cryptosuite as of v3.11.0, not "unsupported".

## Verification
- Full suite **1077 passed** (`test_examples` runs the new script; `test_docs` validates the wiki cross-links), flake8 + mypy clean.
- Example verified end to end locally (authenticated holder, subject == holder).

Docs-only — no release needed; the wiki auto-syncs on the master push.
