### PR TITLE
feat(eudi): trust received SD-JWT badges via X.509 / EU Trusted Lists (#178)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -4,6 +4,22 @@ OpenBadgesLib - Changelog
 Newest first. Dates are ISO 8601 (YYYY-MM-DD).
 
 
+* v3.13.0 - unreleased
+
+  - feat(eudi): **opt-in X.509 / EU Trusted List trust for received SD-JWT
+    badges** (#178). `verify_badge_sd_jwt(..., x5c_trust_anchors=…)` verifies a
+    third-party badge whose issuer JWT carries an `x5c` chain by routing through
+    openvc-core's `verify_credential` pipeline, which path-validates the chain
+    to the caller's X.509 roots and **binds it to `iss`** before using the leaf
+    key — the eIDAS trust root the JWK-pinned suite path cannot reach. Build the
+    anchors from an EU Trusted List with
+    `openvc.trustlist.walk_lotl(...).certificates` (LOTL → national TLs,
+    fail-closed, caller-pinned signers, XXE-hardened) or pass your own roots.
+    JWK-pinning stays the default — exactly one of `pubkey_pem` /
+    `x5c_trust_anchors` is required — and the return type is unchanged
+    (openvc-core's `VerifiedSdJwt`). Status is not checked on this path, as on
+    the pinned one. (Closes #178)
+
 * v3.12.0 - 2026-07-09
 
   - feat(eudi): publish SD-JWT VC **Type Metadata** for the badge `vct`, so a

--- a/openbadgeslib/ob3/eudi.py
+++ b/openbadgeslib/ob3/eudi.py
@@ -223,11 +223,12 @@ def issue_badge_sd_jwt(
 def verify_badge_sd_jwt(
     token: str,
     *,
-    pubkey_pem: Any,
+    pubkey_pem: Any = None,
     audience: Optional[str] = None,
     nonce: Optional[str] = None,
     require_key_binding: bool = False,
     expected_vct: Optional[str] = OB3_SD_JWT_VCT,
+    x5c_trust_anchors: Any = None,
 ) -> Any:
     """Verify a badge SD-JWT VC (issuer form or a holder presentation).
 
@@ -235,7 +236,29 @@ def verify_badge_sd_jwt(
     ``.key_bound``, ``.confirmation``). Raises :class:`EudiError` on any failure.
     Pass *audience*/*nonce* (and ``require_key_binding=True``) to check a Key
     Binding JWT from a holder presentation.
+
+    Trust comes from exactly one of two sources:
+
+    * *pubkey_pem* — pin the issuer's public key (the default; right for a known
+      issuer whose key you already hold).
+    * *x5c_trust_anchors* — a sequence of trusted X.509 root ``Certificate``
+      objects (e.g. an EU Trusted List's ``TrustAnchorSet.certificates`` from
+      ``openvc.trustlist``). Opts into eIDAS **X.509 issuer trust**: a received
+      third-party badge whose issuer JWT carries an ``x5c`` chain is
+      path-validated to those anchors and bound to ``iss`` before its leaf key
+      is used — routed through openvc-core's ``verify_credential`` pipeline (the
+      JWK-pin suite path cannot do X.509 trust). Status is not checked here, as
+      with the pinned path.
     """
+    if x5c_trust_anchors is not None:
+        return _verify_sd_jwt_x5c(
+            token, x5c_trust_anchors, expected_vct=expected_vct,
+            audience=audience, nonce=nonce,
+            require_key_binding=require_key_binding)
+    if pubkey_pem is None:
+        raise EudiError(
+            "verify_badge_sd_jwt needs either pubkey_pem (pin the issuer's key) "
+            "or x5c_trust_anchors (eIDAS X.509 / EU Trusted List trust)")
     _, _, _, SdJwtVcProofSuite = _require_openvc()
     try:
         public_key_jwk = public_jwk_from_pem(pubkey_pem)
@@ -246,3 +269,29 @@ def verify_badge_sd_jwt(
         raise
     except Exception as exc:
         raise EudiError("SD-JWT VC badge verification failed: %s" % exc) from exc
+
+
+def _verify_sd_jwt_x5c(token: str, x5c_trust_anchors: Any, *,
+                       expected_vct: Optional[str], audience: Optional[str],
+                       nonce: Optional[str], require_key_binding: bool) -> Any:
+    """Verify a badge SD-JWT whose issuer JWT carries an ``x5c`` chain against
+    *x5c_trust_anchors* (X.509 roots), via openvc-core's ``verify_credential``
+    pipeline — which path-validates the chain and binds it to ``iss`` before
+    using the leaf key. Returns the underlying ``VerifiedSdJwt``."""
+    try:
+        from openvc import VerificationPolicy, verify_credential
+    except ImportError as exc:
+        raise EudiError(_INSTALL_HINT) from exc
+    policy = VerificationPolicy(
+        expected_vct=expected_vct, audience=audience, nonce=nonce,
+        require_key_binding=require_key_binding, require_status=False)
+    try:
+        result = verify_credential(
+            token, policy=policy, x5c_trust_anchors=x5c_trust_anchors)
+    except EudiError:
+        raise
+    except Exception as exc:
+        raise EudiError(
+            "SD-JWT VC badge verification against the X.509 trust anchors "
+            "failed: %s" % exc) from exc
+    return result.raw

--- a/tests/test_ob3_eudi_x5c.py
+++ b/tests/test_ob3_eudi_x5c.py
@@ -1,0 +1,120 @@
+"""Tests for opt-in X.509 / EU Trusted List trust anchoring in
+verify_badge_sd_jwt (the EUDI SD-JWT track, #178).
+
+A received third-party badge whose issuer JWT carries an `x5c` chain is verified
+by routing through openvc-core's verify_credential pipeline, which path-validates
+the chain to the caller's trust anchors (e.g. an EU Trusted List's
+TrustAnchorSet.certificates) and binds it to `iss`. The crypto needs the [eudi]
+extra and skips without it; the "extra absent" test runs always.
+"""
+import base64
+import datetime as dt
+import sys
+import time
+
+import pytest
+
+from openbadgeslib.ob3.eudi import (OB3_SD_JWT_VCT, EudiError,
+                                    verify_badge_sd_jwt)
+
+ISS = 'https://issuer.example'
+_PAST = dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)
+_FUTURE = dt.datetime(2035, 1, 1, tzinfo=dt.timezone.utc)
+
+
+def _chain():
+    """Build a root -> intermediate -> leaf chain (leaf SAN = ISS). Returns the
+    x5c list [leaf, inter] (DER-base64), the root cert, and the leaf key."""
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.x509.oid import NameOID
+
+    def name(cn):
+        return x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)])
+
+    def cert(subject, issuer, issuer_key, subject_key, *, ca, san=None):
+        builder = (x509.CertificateBuilder()
+                   .subject_name(name(subject)).issuer_name(name(issuer))
+                   .public_key(subject_key.public_key())
+                   .serial_number(x509.random_serial_number())
+                   .not_valid_before(_PAST).not_valid_after(_FUTURE)
+                   .add_extension(x509.BasicConstraints(ca=ca, path_length=None),
+                                  critical=True))
+        if ca:
+            builder = builder.add_extension(x509.KeyUsage(
+                digital_signature=False, content_commitment=False,
+                key_encipherment=False, data_encipherment=False,
+                key_agreement=False, key_cert_sign=True, crl_sign=True,
+                encipher_only=False, decipher_only=False), critical=True)
+        if san:
+            builder = builder.add_extension(
+                x509.SubjectAlternativeName(san), critical=False)
+        return builder.sign(issuer_key, hashes.SHA256())
+
+    def der_b64(crt):
+        return base64.b64encode(
+            crt.public_bytes(serialization.Encoding.DER)).decode('ascii')
+
+    root_key = ec.generate_private_key(ec.SECP256R1())
+    root = cert('root', 'root', root_key, root_key, ca=True)
+    inter_key = ec.generate_private_key(ec.SECP256R1())
+    inter = cert('inter', 'root', root_key, inter_key, ca=True)
+    leaf_key = ec.generate_private_key(ec.SECP256R1())
+    leaf = cert('leaf', 'inter', inter_key, leaf_key, ca=False,
+                san=[x509.UniformResourceIdentifier(ISS)])
+    return [der_b64(leaf), der_b64(inter)], root, leaf_key
+
+
+def _sd_jwt_with_x5c(leaf_key, x5c, *, iss=ISS, vct=OB3_SD_JWT_VCT):
+    """A minimal badge SD-JWT (no disclosures) whose issuer JWT carries *x5c*."""
+    from openvc.keys import P256SigningKey
+    from openvc.proof._jws import sign_compact
+    header = {'alg': 'ES256', 'typ': 'dc+sd-jwt', 'kid': 'leaf',
+              'x5c': list(x5c)}
+    payload = {'iss': iss, 'vct': vct, 'iat': int(time.time()),
+               'name': 'Python 101',
+               'achievement': {'id': 'https://ex/b/1', 'name': 'Python 101'}}
+    return sign_compact(
+        header, payload, signing_key=P256SigningKey(leaf_key, kid='leaf')) + '~'
+
+
+class TestX5cTrust:
+    @pytest.fixture(autouse=True)
+    def _needs_openvc(self):
+        pytest.importorskip('openvc')
+
+    def test_trusted_anchor_verifies_and_binds_issuer(self):
+        x5c, root, leaf_key = _chain()
+        result = verify_badge_sd_jwt(
+            _sd_jwt_with_x5c(leaf_key, x5c), x5c_trust_anchors=[root])
+        assert result.issuer == ISS
+        assert result.vct == OB3_SD_JWT_VCT
+
+    def test_untrusted_anchor_rejected(self):
+        x5c, _root, leaf_key = _chain()
+        unrelated_root = _chain()[1]
+        with pytest.raises(EudiError):
+            verify_badge_sd_jwt(_sd_jwt_with_x5c(leaf_key, x5c),
+                                x5c_trust_anchors=[unrelated_root])
+
+    def test_tampered_signature_rejected(self):
+        x5c, root, leaf_key = _chain()
+        jwt_part, sep, rest = _sd_jwt_with_x5c(leaf_key, x5c).partition('~')
+        head, payload, sig = jwt_part.split('.')
+        sig = ('A' if sig[0] != 'A' else 'B') + sig[1:]     # break the signature
+        with pytest.raises(EudiError):
+            verify_badge_sd_jwt('.'.join([head, payload, sig]) + sep + rest,
+                                x5c_trust_anchors=[root])
+
+    def test_neither_pubkey_nor_anchors_is_rejected(self):
+        x5c, _root, leaf_key = _chain()
+        with pytest.raises(EudiError, match='pubkey_pem'):
+            verify_badge_sd_jwt(_sd_jwt_with_x5c(leaf_key, x5c))
+
+
+def test_x5c_path_needs_the_extra(monkeypatch):
+    for name in ('openvc', 'openvc.keys', 'openvc.proof.sd_jwt'):
+        monkeypatch.setitem(sys.modules, name, None)
+    with pytest.raises(EudiError, match=r'openbadgeslib\[eudi\]'):
+        verify_badge_sd_jwt('x~', x5c_trust_anchors=['anchor'])

--- a/wiki/Python-API-OB3.md
+++ b/wiki/Python-API-OB3.md
@@ -353,6 +353,27 @@ token = issue_badge_sd_jwt(credential, privkey_pem=priv_pem, vct=vct,
 
 The `vct#integrity` claim (a W3C SRI hash over the served bytes) pins the metadata, so a wallet fails closed on any tampering. `badge_type_metadata` / `type_metadata_document_bytes` / `type_metadata_integrity` are pure-Python (no `[eudi]` extra). For issuers who publish a did:web, `openbadges-publish -V 3` **emits this document for you**: set `[issuer] sd_jwt_vct` to a vct under `publish_url` and it is written into the webroot alongside `did.json` (byte-exact, `--check-live`-verified). The default `vct` stays the imsglobal purl, which ships no metadata.
 
+### Verifying a third-party badge via eIDAS X.509 / EU Trusted Lists
+
+`verify_badge_sd_jwt` is **JWK-pinned** by default (`pubkey_pem=…`) — right when you hold the issuer's key. To verify a badge from an **unknown** issuer whose trust root is the eIDAS X.509 world, pass `x5c_trust_anchors` instead: a received badge whose issuer JWT carries an `x5c` chain is path-validated to those roots and **bound to `iss`** before its key is used (delegated to openvc-core's `verify_credential`; the JWK-pin path cannot do X.509 trust). Needs the `[eudi]` extra.
+
+```python
+from openbadgeslib.ob3.eudi import verify_badge_sd_jwt
+
+# Build the anchors from an EU Trusted List with openvc.trustlist (LOTL ->
+# national TLs; fail-closed, caller-pinned LOTL signers, XXE-hardened). See
+# openvc's docs for walk_lotl(); it returns a TrustAnchorSet whose
+# `.certificates` are the trusted roots — or pass your own x509 roots.
+from openvc.trustlist import walk_lotl
+anchors = walk_lotl(...)                          # -> TrustAnchorSet
+
+verified = verify_badge_sd_jwt(received_badge,
+                               x5c_trust_anchors=anchors.certificates)
+print('trusted issuer:', verified.issuer)         # bound to the x5c-validated chain
+```
+
+Exactly one of `pubkey_pem` / `x5c_trust_anchors` is required; the return value is the same `VerifiedSdJwt` either way. The trust-list walk is **fail-closed** (a Trusted List that can't be fetched or whose signature can't be verified contributes zero anchors) and **caller-pinned** (no implicit root); `walk_lotl`'s `select=` filters by qualified-service type. Status is not checked on either path — check it separately if you need it.
+
 ## Presenting a Data Integrity badge over OpenID4VP (`ldp_vc`)
 
 A wallet presents an OB 3.0 **Data Integrity** badge to a relying party as an OpenID4VP 1.0 `ldp_vc` credential: a W3C **Verifiable Presentation** wrapping the badge, secured by a holder **`authentication`** proof bound to the request (`challenge` = the request `nonce`, `domain` = the full, prefixed `client_id`). Building and verifying that presentation is the wallet-exchange rail — it lives in [`openvc-core`](https://pypi.org/project/openvc-core/), not here: openbadgeslib issues the badge, openvc-core carries it. Needs the `[ldp-sd]` extra (see [[Installation]]).


### PR DESCRIPTION
Closes #178 — opt-in X.509 / EU Trusted List trust for received SD-JWT badges. The last EUDI candidate unlocked by openvc-core.

## What
`verify_badge_sd_jwt(..., x5c_trust_anchors=…)` verifies a **third-party** badge whose issuer JWT carries an `x5c` chain: it routes through openvc-core's `verify_credential` pipeline, which path-validates the chain to the caller's X.509 roots and **binds it to `iss`** before using the leaf key — the eIDAS trust root the JWK-pinned suite path cannot reach. Build the anchors from an EU Trusted List (`openvc.trustlist.walk_lotl(...).certificates`) or pass your own roots.

JWK-pinning stays the default — exactly one of `pubkey_pem` / `x5c_trust_anchors` is required — and the return type is unchanged (`VerifiedSdJwt`). Status is not checked on this path, as on the pinned one.

## Changes
- `ob3/eudi.py`: the opt-in `x5c_trust_anchors` path (+ `_verify_sd_jwt_x5c`).
- Docs: Changelog (`feat`, v3.13.0), a "Verifying a third-party badge via eIDAS X.509 / EU Trusted Lists" wiki recipe.

## Verification
- New tests (`tests/test_ob3_eudi_x5c.py`, 5): a root→inter→leaf chain (leaf SAN = `iss`) signs an x5c SD-JWT, verified end to end — trusted anchor **verifies + binds the issuer**; untrusted anchor, tampered signature, and neither-source rejected; missing-extra actionable error.
- Full suite **1096 passed**, flake8 + mypy clean, test_docs OK.
