### PR TITLE
docs(governance): CONTRIBUTING, GOVERNANCE, issue/PR templates (#174)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,57 @@
+name: Bug report
+description: Something in openbadgeslib does not work as documented.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. For a suspected **security vulnerability** do **not** use this
+        form — follow [SECURITY.md](https://github.com/luisgf/openbadgeslib/blob/master/SECURITY.md)
+        (private advisory or email).
+  - type: input
+    id: version
+    attributes:
+      label: openbadgeslib version
+      description: Output of `pip show openbadgeslib`. Please try the latest release first.
+      placeholder: "3.13.0"
+    validations:
+      required: true
+  - type: input
+    id: python
+    attributes:
+      label: Python version
+      placeholder: "3.12"
+    validations:
+      required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+      description: What you observed, and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: >
+        The smallest code or CLI invocation (with inputs) that shows the problem.
+        Redact any private keys or personal data.
+      render: shell
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - OB 3.0 (VC-JWT)
+        - OB 3.0 Data Integrity / LDP
+        - OB 3.0 EUDI SD-JWT
+        - OB 2.0
+        - OB 1.0
+        - CLI / config
+        - Publishing / status lists
+        - Other / not sure
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/capability_request.yml
+++ b/.github/ISSUE_TEMPLATE/capability_request.yml
@@ -1,0 +1,54 @@
+name: Capability request
+description: Request a feature or capability — and give the use case that justifies it.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Several roadmap items are built **when someone asks with a concrete use case** — this
+        form is that signal. The clearer the use case, the sooner it can land.
+  - type: textarea
+    id: capability
+    attributes:
+      label: What capability do you want?
+    validations:
+      required: true
+  - type: textarea
+    id: usecase
+    attributes:
+      label: Concrete use case
+      description: >
+        What are you building, and what does this unblock? This is the part that prioritises
+        the work.
+    validations:
+      required: true
+  - type: dropdown
+    id: track
+    attributes:
+      label: Which track / spec?
+      options:
+        - OB 3.0 (VC-JWT)
+        - OB 3.0 Data Integrity / LDP
+        - OB 3.0 EUDI SD-JWT / eIDAS
+        - OB 2.0
+        - CLI / tooling
+        - Other
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives or workarounds
+      description: Anything you have tried, or existing tools that do part of this.
+    validations:
+      required: false
+  - type: dropdown
+    id: help
+    attributes:
+      label: Would you help?
+      options:
+        - I can test a prototype
+        - I can contribute a PR
+        - I am just requesting
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability (private)
+    url: https://github.com/luisgf/openbadgeslib/security/advisories/new
+    about: >
+      Report a suspected vulnerability privately — never as a public issue.
+      See SECURITY.md.
+  - name: Question or usage help
+    url: https://github.com/luisgf/openbadgeslib/wiki
+    about: >
+      Check the wiki first (Quick Start, Guides, Python API, CLI Reference).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+<!-- Thanks for contributing! See CONTRIBUTING.md for the full expectations. -->
+
+## What and why
+
+<!-- What does this change, and why? Link the issue it closes, e.g. "Closes #123". -->
+
+## Checklist
+
+- [ ] `flake8 openbadgeslib tests`, `mypy`, and `pytest` pass locally — with the
+      `[ldp]` / `[eudi]` extras installed if this touches those tracks (otherwise
+      their tests silently skip).
+- [ ] Commit messages follow the Conventional Commits convention
+      (`type(scope): …`, imperative, ≤ 80 chars); the `gitlint` check passes.
+- [ ] A user-facing change (`feat` / `fix` / `security` / `perf`) adds its
+      `Changelog.txt` entry under a `* vX.Y.Z - unreleased` header.
+- [ ] Docs / wiki updated if behaviour or the public API changed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,93 @@
+# Contributing to openbadgeslib
+
+Thanks for your interest in improving **openbadgeslib** — a library and CLI for
+issuing and verifying OpenBadges 2.0 and 3.0 credentials. This page is the quick
+entry point; the full developer guide lives in the wiki
+([Contributing](https://github.com/luisgf/openbadgeslib/wiki/Contributing),
+[Releasing](https://github.com/luisgf/openbadgeslib/wiki/Releasing)).
+
+## Reporting bugs and requesting capabilities
+
+- **Bugs:** open a [Bug report](https://github.com/luisgf/openbadgeslib/issues/new/choose).
+  Include the openbadgeslib version, your Python version, and a minimal
+  reproduction.
+- **Capabilities / features:** open a
+  [Capability request](https://github.com/luisgf/openbadgeslib/issues/new/choose).
+  This is also the **demand signal** the roadmap runs on — several planned items
+  are deliberately *built when someone asks for them with a concrete use case*,
+  so a well-described request genuinely moves them forward.
+- **Security vulnerabilities:** do **not** open a public issue. Follow
+  [SECURITY.md](SECURITY.md) (private GitHub advisory or email).
+
+## Development setup
+
+Requires a supported Python (see below). Everything runs from an editable
+virtual environment:
+
+```sh
+git clone https://github.com/luisgf/openbadgeslib
+cd openbadgeslib
+python3 -m venv .venv && source .venv/bin/activate
+pip install --upgrade pip
+pip install -e ".[dev]"          # add ,ldp and ,eudi to exercise those tracks
+```
+
+## The checks a pull request must pass
+
+CI runs these on Python 3.10–3.14; run them locally before opening a PR (via
+your `.venv`):
+
+```sh
+flake8 openbadgeslib tests       # style (max-line-length = 120, see setup.cfg)
+mypy                             # types (config in pyproject.toml)
+pytest                           # the suite; install [ldp]/[eudi] so their
+                                 # tests actually run instead of skipping
+```
+
+The Data Integrity (LDP) tests need the `[ldp]` extra (pyld) and the EUDI
+SD-JWT / X.509 tests need `[eudi]` — without them those tests silently
+`importorskip`, so install the extras when touching those areas. Coverage is
+enforced at a floor (currently 93%).
+
+## Commit messages
+
+Commits follow a [Conventional Commits](https://www.conventionalcommits.org/)
+style so the history is machine-readable and the changelog can be drafted from
+it — CI's `gitlint` check enforces the title format. The shape is
+`type(optional-scope)!: imperative summary` (≤ 80 chars), with the vocabulary:
+
+| Type | For | Changelog |
+| --- | --- | --- |
+| `feat` / `fix` / `security` / `perf` | user-facing change | **yes** |
+| `docs` / `test` / `refactor` / `chore` / `ci` / `build` / `style` | internal, no user-visible effect | no |
+| `release` | the version-bump/changelog commit | no |
+
+A `!` (or a `BREAKING CHANGE:` body trailer) marks a breaking change. A
+user-facing `feat`/`fix`/`security`/`perf` should add its `Changelog.txt` entry
+in the same commit (newest-first, under a `* vX.Y.Z - unreleased` header). See
+the wiki [Contributing](https://github.com/luisgf/openbadgeslib/wiki/Contributing)
+page for the full convention.
+
+## Supported Python versions
+
+openbadgeslib supports **every CPython release that is not end-of-life**. The
+policy is deliberately simple and predictable:
+
+- A version is **dropped** — from `requires-python`, the classifiers, and the CI
+  matrix — at the next **major** release after it reaches end-of-life. For
+  example, Python **3.10 (EOL 2026-10)** is dropped in **4.0.0**; until then it
+  stays supported. Grouping drops into majors keeps breaking changes rare.
+- A new CPython minor is **added** to the CI matrix once it has a stable
+  (non-pre) release, so downstreams can adopt it early.
+- The current matrix is **3.10–3.14**, and `requires-python = ">=3.10"`.
+
+Security fixes always target the latest release only (see
+[SECURITY.md](SECURITY.md)).
+
+## Governance and licensing
+
+Project governance, the release process, and the maintenance/continuity plan are
+in [GOVERNANCE.md](GOVERNANCE.md). The library is licensed under the LGPLv3 and
+the CLI entry points under BSD-2-Clause (see
+[LICENSE.txt](LICENSE.txt)); by contributing you agree your contribution is
+provided under those same terms.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,72 @@
+# Governance
+
+How **openbadgeslib** is maintained, released, and kept available. It is a small
+project with a clear, lightweight process — written down here because third
+parties already depend on it to *verify* credentials, so continuity matters.
+
+## Maintainership
+
+openbadgeslib is actively maintained by **Luis González Fernández**
+(`luisgf@luisgf.es`), the single active maintainer, who decides on scope,
+roadmap, and releases. The project has a historical co-author, Jesús Cea Avión,
+credited in the copyright headers and
+[Authors, License and FAQ](https://github.com/luisgf/openbadgeslib/wiki/Authors-License-and-FAQ);
+active maintenance today is solo.
+
+Decision-making is lightweight: the roadmap is tracked as GitHub issues (label
+`roadmap`, tracking issue
+[#175](https://github.com/luisgf/openbadgeslib/issues/175)), and several items
+are built on demand — a [capability request](CONTRIBUTING.md) with a concrete
+use case is how they get prioritised.
+
+## Releasing and publishing
+
+Releases are **CI-driven and credential-less to publish**:
+
+- The version is single-sourced in `openbadgeslib/util.py`; a pushed `vX.Y.Z`
+  tag triggers the CI workflow, which runs the full test matrix (Python
+  3.10–3.14) and then publishes to
+  [PyPI](https://pypi.org/project/openbadgeslib/).
+- Publishing uses **PyPI Trusted Publishing (OIDC)** — there is **no long-lived
+  PyPI API token** stored anywhere. The publish job authenticates to PyPI from
+  GitHub Actions via a short-lived OIDC token, so there is no release secret to
+  leak, rotate, or lose.
+- Each release is announced as a **GitHub Release** with curated notes drawn
+  from `Changelog.txt`; the Release is the canonical announcement channel.
+- The **human fallback** (a maintainer cutting a release by hand) is fully
+  documented in the wiki
+  [Releasing](https://github.com/luisgf/openbadgeslib/wiki/Releasing) runbook —
+  it needs only repository write access plus the CI pipeline, no personal
+  credentials.
+
+## Bus factor and continuity
+
+A single active maintainer is a real risk for a library others verify with. The
+mitigations are deliberate:
+
+1. **No secret is a single point of failure.** Trusted Publishing means losing
+   access to a token cannot happen — there isn't one. Publishing is bound to the
+   GitHub repository's identity, not a person's stored key.
+2. **The whole release process is documented and automated** (the wiki Releasing
+   runbook and the `release` skill), so anyone with repository access can ship a
+   fix without tribal knowledge.
+3. **Handover requirements are explicit.** Taking over maintenance needs two
+   grants: **GitHub** repository admin, and **PyPI** owner/maintainer on the
+   [`openbadgeslib` project](https://pypi.org/project/openbadgeslib/) plus the
+   configured Trusted Publisher. A new maintainer with both can release
+   immediately.
+
+**Recommended hardening (maintainer action):** add a second **PyPI project
+owner** and a backup **GitHub admin** so a bus event does not strand the
+project. Until then, note that everything published stays available on PyPI
+indefinitely, and the LGPLv3 permits anyone to fork and continue the work.
+
+If the project were to become unmaintained, the last release remains installable
+from PyPI, and this document plus the wiki are enough for a fork to pick it up.
+
+## Reporting and contact
+
+- Bugs and capability requests: GitHub issues (see [CONTRIBUTING.md](CONTRIBUTING.md)).
+- Security vulnerabilities: **privately**, per [SECURITY.md](SECURITY.md) — never
+  a public issue.
+- General contact: `luisgf@luisgf.es`.

--- a/README.md
+++ b/README.md
@@ -297,6 +297,16 @@ flake8 openbadgeslib tests      # lint
 mypy                            # type check (config in pyproject.toml)
 ```
 
+## Contributing
+
+Bug reports,
+[capability requests](https://github.com/luisgf/openbadgeslib/issues/new/choose)
+(the roadmap's demand signal), and pull requests are welcome — see
+[`CONTRIBUTING.md`](CONTRIBUTING.md) for the workflow and the supported-Python
+policy, and [`GOVERNANCE.md`](GOVERNANCE.md) for maintenance and release
+governance. Security issues go through [`SECURITY.md`](SECURITY.md), never a
+public issue.
+
 ## Changelog
 
 See [`Changelog.txt`](Changelog.txt) for the full history, and the


### PR DESCRIPTION
Closes #174 — write the project's governance down. Docs only, no code, no release.

## What
- **CONTRIBUTING.md** (root): dev setup, the flake8/mypy/pytest gate, the Conventional-Commits convention, and a written **Python support policy** — support every non-EOL CPython, drop at the next major (3.10 EOL 2026-10 → 4.0.0), add new minors once stable. Codifies current practice and unblocks #170.
- **GOVERNANCE.md** (root): maintainership, the credential-less Trusted-Publishing release path + its documented human fallback, the **bus-factor / continuity** plan (handover needs GitHub admin + PyPI ownership), and GitHub Releases as the canonical announcement channel.
- **.github/**: bug-report + **capability-request** issue forms (the roadmap's demand-detection channel), a config routing security reports to the private advisory, and a PR checklist template.
- **README**: a Contributing section linking these.

## Not in this PR (recommended maintainer actions, documented in GOVERNANCE)
- Enable **GitHub Discussions** (visibility + demand signal).
- Add a **second PyPI project owner** + a backup **GitHub admin** (bus-factor hardening).

## Verification
- Issue-form YAML valid; `flake8` / `mypy` / `test_docs` clean (no code or wiki touched).
