### PR TITLE
Milestone 5 (R2 mid-term): architecture, logic, security & CI hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ jobs:
         run: mypy
 
       - name: Test (pytest + coverage)
+        # This job installs [ldp-sd] on purpose, so demand it: the ecdsa-sd-2023
+        # suite FAILs (not skips) if openvc/pyld stop importing here (#221). The
+        # windows leg below omits the extra and does not set this, so it skips.
+        env:
+          OPENBADGES_REQUIRE_LDP_SD: '1'
         run: pytest --cov=openbadgeslib --cov-report=term-missing
 
   windows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,38 @@ jobs:
       - name: Test (pytest + coverage)
         run: pytest --cov=openbadgeslib --cov-report=term-missing
 
+  windows:
+    # "OS Independent" was only a classifier — nothing non-Linux was ever
+    # exercised. On Windows fcntl is absent, so the StatusRegistry advisory lock
+    # degrades to a no-op (status_registry.py:41-44,86-92), a path no Linux run
+    # takes. Run the suite on windows-latest with the core extras only (the
+    # [ldp]/[eudi] crypto tests skip when their wheels are absent), so nothing
+    # Windows-specific silently rots. Independent of the publish gate (publish
+    # `needs: test`), so a Windows-only quirk never blocks a release. See #230,
+    # and the flock work in #148.
+    name: test (windows, py${{ matrix.python-version }})
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.12']
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install package and dev dependencies (core, no network extras)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Test (pytest)
+        run: pytest
+
   eudi:
     # Hardening for the optional [eudi] SD-JWT VC track, which delegates its
     # crypto to openvc-core (a separate repo). The main `test` job installs the
@@ -132,7 +164,10 @@ jobs:
           python -m build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # SHA-pinned (not the mutable release/v1 branch): this step runs with
+        # id-token: write, so a compromised upstream ref could publish under our
+        # OIDC identity. Dependabot (.github/dependabot.yml) bumps the pin.
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           # OIDC Trusted Publishing: no password — the id-token permission
           # above authenticates to PyPI. This REQUIRES a Trusted Publisher

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -10,6 +10,12 @@ on:
     branches: [master]
   pull_request:
 
+# Least-privilege GITHUB_TOKEN: this workflow only reads the repo to lint the
+# commit range; it writes nothing. Without an explicit block it would inherit
+# the repository/organization default, which may be broader (#230).
+permissions:
+  contents: read
+
 jobs:
   commit-lint:
     name: Lint commit messages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,9 @@ jobs:
           pip install -e ".[dev]"
       - name: Build API reference (pdoc)
         run: pdoc openbadgeslib -o site -d google
-      - uses: actions/upload-pages-artifact@v5
+      # SHA-pinned: the Pages pipeline runs under the workflow's id-token: write.
+      # Dependabot (.github/dependabot.yml) bumps the pin.
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5
         with:
           path: site
 
@@ -46,4 +48,5 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v5
+        # SHA-pinned (runs with id-token: write). Dependabot bumps the pin.
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -147,7 +147,12 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     least-privilege `permissions: contents: read` to commit-lint.yml. Add a
     `windows-latest` CI leg plus a monkeypatched test of the `fcntl=None`
     StatusRegistry lock fallback, so the "OS Independent" classifier is actually
-    exercised on the non-POSIX path (#230).
+    exercised on the non-POSIX path. The leg immediately caught a real
+    portability bug it fixes: `openbadges-publish` now records `files_written`
+    with forward slashes (a Windows `\` would have broken the artefact URLs built
+    via `urljoin`); the POSIX file-mode assertions skip on Windows and the
+    ldp-sd hard-fail guard keys on an explicit `OPENBADGES_REQUIRE_LDP_SD` flag
+    (set by the main test job) so the core-only Windows leg skips it (#230).
   - refactor: declare the stable public surface (freeze prep for v4). The root
     package gains an explicit `__all__` (the "public contract"), re-exports
     `KeyEd25519` (the recommended OB 3.0 / LDP key) alongside `KeyRSA`/`KeyECC`,

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -148,6 +148,16 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     `windows-latest` CI leg plus a monkeypatched test of the `fcntl=None`
     StatusRegistry lock fallback, so the "OS Independent" classifier is actually
     exercised on the non-POSIX path (#230).
+  - refactor: declare the stable public surface (freeze prep for v4). The root
+    package gains an explicit `__all__` (the "public contract"), re-exports
+    `KeyEd25519` (the recommended OB 3.0 / LDP key) alongside `KeyRSA`/`KeyECC`,
+    and exposes the `ob2`/`ob3`/`errors` subpackages and the
+    `issue_from_conf`/`verify_badge` facades by name. `openbadgeslib.ob3`
+    re-exports the `eudi` SD-JWT VC track (its heavy imports stay lazy).
+    `SignResult.credential`/`.assertion` and the `_Ob3Context` fields are typed
+    with `TYPE_CHECKING` forward refs instead of `Any` (zero runtime cost,
+    correct autocompletion / pdoc). Adds a "Stable API" wiki page documenting
+    the stable-vs-internal boundary (#232).
 
 
 * v3.14.0 - 2026-07-10

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -119,6 +119,16 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     so a revoked credential could be silently resurrected. `PublishResult` gains
     a `no_validity_bound` list (surfaced in the CLI's human output and `--json`),
     and the config example documents the republication cadence (#227).
+  - security(ob3): SD-JWT VC (EUDI) issuance no longer silently drops a
+    credential's `credentialStatus`. Because SD-JWT VC status carriage/checking
+    is not wired yet (both verify paths hard-set `require_status=False`), an
+    SD-JWT VC badge is irrevocable; `issue_badge_sd_jwt` now rejects a credential
+    that carries a `credentialStatus` with a clear `EudiError` (before requiring
+    the [eudi] extra) rather than issue a badge the issuer believes is revocable.
+    `badge_to_sd_jwt_claims` also carries `credentialSubject.identifier` (the
+    hashed recipient identities), so a badge whose subject travelled via
+    `identifier` (no `id`) keeps a checkable recipient. The irrevocability is
+    documented prominently on the issue/verify docstrings (#226).
 
 
 * v3.14.0 - 2026-07-10

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -85,6 +85,17 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     required key surfaces as `IssuanceError` through the `issue_*` entry points,
     and a missing image raises a typed error instead of `print` + bare
     `IOError` (#223).
+  - refactor(errors): consolidate the exception hierarchy so a single
+    `except LibOpenBadgesException` traps every library error. `IssuanceError`
+    and `DecompressionLimitExceeded` are re-anchored under the root (still
+    importable from `openbadgeslib.issue` / `openbadgeslib.baking`); the config
+    helpers' bare `ValueError`s become a new `ConfigError` and the signers'
+    unsupported-algorithm error becomes `UnsupportedAlgorithm` — both also
+    subclass `ValueError` so `except ValueError` callers keep working.
+    `_write_badge_and_log` reads the `[logs]` path inside its `try`, so a missing
+    `[logs]` section is reported instead of crashing with a traceback after the
+    badge is already on disk. Adds singular aliases (`KeyGenException`,
+    `SignerException`, `VerifierException`) for the plural base families (#224).
 
 
 * v3.14.0 - 2026-07-10

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -103,6 +103,15 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     while OB3 anchored it to UTC, so the same timestamp emitted a different
     instant in OB2 than in OB3; the single implementation keeps OB3's
     naive=>UTC rule (#225).
+  - feat(confparser): resolve config through typed dataclasses with centralized
+    defaults. `load_config(path) -> ConfigParser` is the library entry point
+    (raises `ConfigError`); `read_config_or_exit` is now a thin CLI wrapper over
+    it (and the flagship example uses `load_config`). New `IssuerConfig` /
+    `BadgeSectionConfig` dataclasses (extending the `OB3StatusConfig` pattern)
+    resolve the `[issuer]` and badge sections and their defaults once (issuer id,
+    `criteria_narrative`->`criteria` fallback, hosted-assertions base), and a
+    single `DEFAULT_KEY_TYPE` + `resolve_key_type()` centralises the key_type
+    name->KeyType mapping the keygenerator used to inline (#225).
 
 
 * v3.14.0 - 2026-07-10

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -139,6 +139,15 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     request and every redirect. Also adds a wall-clock download budget
     (`MAX_DOWNLOAD_SECONDS`, 60 s), since the per-socket `timeout=30` bounds each
     read but not a slow-drip response's total time (#231).
+  - ci: harden the release-critical workflows. SHA-pin the actions that run with
+    `id-token: write` — `pypa/gh-action-pypi-publish` (PyPI Trusted Publishing)
+    and the GitHub Pages `upload-pages-artifact` / `deploy-pages` — so a
+    compromised upstream tag cannot publish or deploy under our OIDC identity
+    (Dependabot already tracks github-actions and bumps the pins). Add a
+    least-privilege `permissions: contents: read` to commit-lint.yml. Add a
+    `windows-latest` CI leg plus a monkeypatched test of the `fcntl=None`
+    StatusRegistry lock fallback, so the "OS Independent" classifier is actually
+    exercised on the non-POSIX path (#230).
 
 
 * v3.14.0 - 2026-07-10

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -76,6 +76,15 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     `CredentialNotFound` / `AmbiguousCredential` instead of exiting.
     `openbadges-publish -V 3` is now a thin presenter over it (byte-identical
     output). Completes #222.
+  - fix(issue): move the version-neutral badge config model (`Badge`,
+    `BadgeImgType`) out of the legacy `ob1` package into
+    `openbadgeslib.badge_model` (re-exported from `ob1.badge` for
+    compatibility). `create_from_conf` now reads the OpenBadges 1.0-only
+    `verify_key`/`criteria` keys optionally, so issuing an OB3 badge that omits
+    them no longer blows up with a raw `KeyError('verify_key')`; a missing
+    required key surfaces as `IssuanceError` through the `issue_*` entry points,
+    and a missing image raises a typed error instead of `print` + bare
+    `IOError` (#223).
 
 
 * v3.14.0 - 2026-07-10

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -112,6 +112,13 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     `criteria_narrative`->`criteria` fallback, hosted-assertions base), and a
     single `DEFAULT_KEY_TYPE` + `resolve_key_type()` centralises the key_type
     name->KeyType mapping the keygenerator used to inline (#225).
+  - security(ob3): warn loudly when `openbadges-publish -V 3` regenerates a
+    revocable badge's status lists without a `validUntil` bound (no
+    `status_validity_days` set). An unbounded list has no anti-replay freshness —
+    an authentic older copy with fewer revocations passes the window unchecked,
+    so a revoked credential could be silently resurrected. `PublishResult` gains
+    a `no_validity_bound` list (surfaced in the CLI's human output and `--json`),
+    and the config example documents the republication cadence (#227).
 
 
 * v3.14.0 - 2026-07-10

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -96,6 +96,13 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     `[logs]` section is reported instead of crashing with a traceback after the
     badge is already on disk. Adds singular aliases (`KeyGenException`,
     `SignerException`, `VerifierException`) for the plural base families (#224).
+  - refactor(ob2, ob3): deduplicate the shared JSON helpers (`_iso`,
+    `_parse_iso`, `_as_dict`, `_require`) into an internal
+    `openbadgeslib._jsonmodel`. The two copies had drifted: OB2's `_iso`
+    serialised a naive datetime as *local* time (`astimezone` on a naive value)
+    while OB3 anchored it to UTC, so the same timestamp emitted a different
+    instant in OB2 than in OB3; the single implementation keeps OB3's
+    naive=>UTC rule (#225).
 
 
 * v3.14.0 - 2026-07-10

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -129,6 +129,16 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
     hashed recipient identities), so a badge whose subject travelled via
     `identifier` (no `id`) keeps a checkable recipient. The irrevocability is
     documented prominently on the issue/verify docstrings (#226).
+  - security(util): pin the SSRF-validated IP on the HTTPS connection to defeat
+    DNS rebinding. `_assert_public_host` validated the resolved IPs, but
+    `opener.open` then re-resolved on its own, so a hostile DNS (TTL 0) could
+    answer public during the check and internal (169.254.169.254 / loopback /
+    RFC1918) at the real connect. A new `_PinnedHTTPSConnection` re-resolves,
+    re-validates and dials the validated IP in one step (keeping the hostname
+    for TLS SNI / certificate verification and the Host header) — for the initial
+    request and every redirect. Also adds a wall-clock download budget
+    (`MAX_DOWNLOAD_SECONDS`, 60 s), since the per-socket `timeout=30` bounds each
+    read but not a slow-drip response's total time (#231).
 
 
 * v3.14.0 - 2026-07-10

--- a/examples/issue_from_config.py
+++ b/examples/issue_from_config.py
@@ -14,7 +14,7 @@ See the "Library Integration Tutorial" wiki page for the narrative and the
 import tempfile
 from pathlib import Path
 
-from openbadgeslib.confparser import read_config_or_exit
+from openbadgeslib.confparser import load_config
 from openbadgeslib.issue import issue_batch_from_conf, issue_from_conf
 from openbadgeslib.keys import KeyFactory, KeyType
 from openbadgeslib.ob3 import OB3Verifier
@@ -62,7 +62,10 @@ def _write_project(root: Path) -> Path:
 def main() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
-        conf = read_config_or_exit(str(_write_project(root)))
+        # load_config is the library entry point: it raises ConfigError (which a
+        # real app would catch) instead of printing and exiting like the CLI
+        # helper read_config_or_exit.
+        conf = load_config(str(_write_project(root)))
 
         # The badge is named by its config *section*: '[badge_python_101]' →
         # 'badge_python_101' (the CLI's -b takes the short 'python_101' and

--- a/openbadgeslib/__init__.py
+++ b/openbadgeslib/__init__.py
@@ -23,6 +23,13 @@
 
 from typing import Any
 
+# ── Submodule entry points ───────────────────────────────────────────────────
+# Bind ob2 / ob3 / errors as attributes so they are part of the explicit public
+# surface (and `from openbadgeslib import *`): ob2 (strict OB 2.0), ob3 (OB 3.0,
+# incl. ob3.eudi and ob3.OB3Ldp*), and the errors hierarchy rooted at
+# LibOpenBadgesException.
+from . import ob2, ob3, errors  # noqa: F401
+
 # ── OpenBadges 2.0 (strict) ──────────────────────────────────────────────────
 from .ob2 import (  # noqa: F401
     OB2Signer, OB2Verifier, OB2VerificationError,
@@ -35,17 +42,21 @@ from .ob3 import (  # noqa: F401
 )
 
 # ── Shared utilities ────────────────────────────────────────────────────────────
-from .keys import KeyFactory, KeyRSA, KeyECC  # noqa: F401
+# KeyEd25519 is the recommended key type for OB 3.0 / LDP (eddsa-rdfc-2022).
+from .keys import KeyFactory, KeyRSA, KeyECC, KeyEd25519  # noqa: F401
 from .util import __version__  # noqa: F401
 
 
-# ── Issuance API ─────────────────────────────────────────────────────────────
-# "Issue badge X to Y per config" as a library call — the orchestration the CLI
-# wraps, returning a SignResult instead of writing files (openbadgeslib.issue).
-# Resolved lazily (PEP 562, below) because openbadgeslib.issue pulls in the
-# shared Badge model from the ob1 leaf module; a bare `import openbadgeslib`
-# must not drag that in. `from openbadgeslib.issue import ...` works directly.
-_ISSUE_API = ('IssuanceError', 'SignResult', 'issue_from_conf')
+# ── Issuance / verification API ──────────────────────────────────────────────
+# "Issue badge X to Y per config" / "verify this badge" as library calls — the
+# orchestration the CLIs wrap, returning a SignResult / VerifyResult instead of
+# doing I/O (openbadgeslib.issue, openbadgeslib.verify). Resolved lazily (PEP
+# 562, below) so a bare `import openbadgeslib` stays lightweight;
+# `from openbadgeslib.issue import ...` / `.verify import ...` work directly.
+_ISSUE_API = {
+    'IssuanceError': 'issue', 'SignResult': 'issue', 'issue_from_conf': 'issue',
+    'verify_badge': 'verify',
+}
 
 
 # ── OpenBadges 1.0 (legacy) ──────────────────────────────────────────────────
@@ -66,10 +77,11 @@ _OB1_API = {
 
 def __getattr__(name: str) -> Any:
     if name in _ISSUE_API:
-        # The modern issuance API — lazy so a bare import stays ob1-free, but
-        # warning-free (unlike the OB1 names below).
+        # The modern issuance / verification API — lazy so a bare import stays
+        # lightweight, but warning-free (unlike the OB1 names below).
         import importlib
-        return getattr(importlib.import_module('.issue', __name__), name)
+        return getattr(
+            importlib.import_module('.' + _ISSUE_API[name], __name__), name)
     module = _OB1_API.get(name)
     if module is None:
         raise AttributeError(
@@ -83,3 +95,24 @@ def __getattr__(name: str) -> Any:
         'the "OpenBadges 1.0 lifecycle" wiki page.' % name,
         DeprecationWarning, stacklevel=2)
     return getattr(importlib.import_module('.ob1.' + module, __name__), name)
+
+
+# The stable, supported top-level surface (the "public contract" — see the
+# "Stable API vs internals" wiki/doc page). Everything else (the ob1.* legacy
+# names resolved lazily above, and any underscore-prefixed name) is internal.
+# The issuance/verification facades are resolved lazily by __getattr__ but are
+# part of the contract, so they are listed here for pdoc and `import *`.
+__all__ = [
+    '__version__',
+    # Subpackage entry points.
+    'ob2', 'ob3', 'errors',
+    # OpenBadges 2.0 (strict).
+    'OB2Signer', 'OB2Verifier', 'OB2VerificationError',
+    # OpenBadges 3.0.
+    'OB3Signer', 'OB3Verifier', 'OB3VerificationError',
+    'OpenBadgeCredential', 'Achievement', 'Issuer',
+    # Keys (KeyEd25519 is the recommended OB 3.0 / LDP key type).
+    'KeyFactory', 'KeyRSA', 'KeyECC', 'KeyEd25519',
+    # Programmatic issue / verify facades (resolved lazily).
+    'issue_from_conf', 'verify_badge', 'IssuanceError', 'SignResult',
+]

--- a/openbadgeslib/_jsonmodel.py
+++ b/openbadgeslib/_jsonmodel.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+        OpenBadges Library
+
+        Copyright (c) 2014-2026, Luis González Fernández, luisgf@luisgf.es
+        Copyright (c) 2014-2026, Jesús Cea Avión, jcea@jcea.es
+
+        All rights reserved.
+
+        This library is free software; you can redistribute it and/or
+        modify it under the terms of the GNU Lesser General Public
+        License as published by the Free Software Foundation; either
+        version 3.0 of the License, or (at your option) any later version.
+
+        This library is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+        Lesser General Public License for more details.
+
+        You should have received a copy of the GNU Lesser General Public
+        License along with this library.
+"""
+
+# Shared JSON <-> dataclass helpers for the OB2 and OB3 models. These lived in
+# duplicate in openbadgeslib.ob2.models and openbadgeslib.ob3.credential and had
+# drifted: the OB2 copy of ``_iso`` ran ``astimezone`` on a *naive* datetime,
+# which Python interprets as **local** time — so the same value serialised to a
+# different instant in OB2 than in OB3 (which anchors naive datetimes to UTC).
+# This module keeps the OB3 semantics (naive => UTC) as the single source of
+# truth, matching ob3.status_registry._iso_z and the JWT nbf/exp claims.
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+def _iso(dt: datetime) -> str:
+    """Return a datetime as an ISO 8601 string with a ``Z`` (UTC) suffix.
+
+    A naive datetime is assumed to be UTC (not local time), so validFrom/
+    validUntil and OB2 issuedOn/expires never silently shift by the host's
+    offset and stay consistent with the JWT nbf/exp claims.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_iso(value: Any, where: str = 'date') -> datetime:
+    """Parse an ISO 8601 timestamp (with a UTC offset or trailing ``Z``).
+
+    A non-string (e.g. a bare Unix timestamp, the legacy OB 1.0 shape) is
+    rejected, as is a naive timestamp with no offset — verify() always compares
+    against an aware ``datetime.now(timezone.utc)``, so only unambiguously
+    anchored timestamps are accepted. Raises ValueError otherwise, naming
+    *where* the bad value came from.
+    """
+    if not isinstance(value, str):
+        raise ValueError("%s must be an ISO 8601 string, got %r" % (where, value))
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("invalid ISO 8601 date in %s: %r" % (where, value)) from exc
+    if dt.tzinfo is None:
+        raise ValueError("%s is missing a UTC offset: %r" % (where, value))
+    return dt
+
+
+def _as_dict(value: Any, where: str) -> dict[str, Any]:
+    """Return *value* if it is a dict, else raise a clear ValueError."""
+    if not isinstance(value, dict):
+        raise ValueError("%s must be a JSON object" % where)
+    return value
+
+
+def _require(data: dict[str, Any], key: str, where: str) -> str:
+    """Return ``data[key]`` as a non-empty string, raising a clear ValueError if
+    it is missing, empty, or not a string. All fields validated here are
+    identifiers consumed as strings downstream (e.g. recipient binding calls
+    ``.lower()``), so a non-string value must be rejected rather than crash
+    later."""
+    value = data.get(key)
+    if value is None or value == "":
+        raise ValueError("missing required field %s.%s" % (where, key))
+    if not isinstance(value, str):
+        raise ValueError("field %s.%s must be a string" % (where, key))
+    return value

--- a/openbadgeslib/badge_model.py
+++ b/openbadgeslib/badge_model.py
@@ -1,0 +1,199 @@
+"""
+        OpenBadges Library
+
+        Copyright (c) 2014-2026, Luis González Fernández, luisgf@luisgf.es
+
+        All rights reserved.
+
+        This library is free software; you can redistribute it and/or
+        modify it under the terms of the GNU Lesser General Public
+        License as published by the Free Software Foundation; either
+        version 3.0 of the License, or (at your option) any later version.
+
+        This library is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+        Lesser General Public License for more details.
+
+        You should have received a copy of the GNU Lesser General Public
+        License along with this library.
+"""
+
+# The version-neutral badge config model, shared by every OpenBadges version.
+#
+# ``Badge`` and ``BadgeImgType`` map a ``[badge_*]`` config section (its name,
+# description, image and signing key) onto the object the OB1/OB2/OB3 signers
+# consume. They lived in ``ob1.badge`` for historical reasons, so every modern
+# module imported the shared model out of the legacy package; they now live here
+# in neutral territory (``ob1.badge`` re-exports them for compatibility).
+#
+# create_from_conf requires only the keys every version uses — name,
+# description, the signing key pair and the local image. ``verify_key`` and
+# ``criteria`` are OpenBadges 1.0 fields and are read optionally, so issuing an
+# OB 3.0 badge no longer needs them (they are absent from a 3.0-only config).
+
+import os
+from enum import Enum
+from typing import Any, Optional, Union
+
+from .keys import KeyType, detect_key_type
+from .errors import (BadgeImgFormatUnsupported, ErrorParsingFile,
+                     UnknownKeyType, PrivateKeyReadError, PublicKeyReadError)
+from .util import download_file
+
+
+class BadgeImgType(Enum):
+    SVG = 0
+    PNG = 1
+
+
+class Badge():
+    def __init__(self, ini_name: Optional[str] = None, name: Optional[str] = None,
+                 description: Optional[str] = None, image_type: Optional[BadgeImgType] = None,
+                 image: Optional[bytes] = None, image_url: Optional[str] = None,
+                 criteria_url: Optional[str] = None, json_url: Optional[str] = None,
+                 verify_key_url: Optional[str] = None, key_type: Optional[KeyType] = None,
+                 privkey_pem: Optional[Union[str, bytes]] = None,
+                 pubkey_pem: Optional[Union[str, bytes]] = None) -> None:
+
+        self.ini_name = ini_name
+        self.name = name
+        self.description = description
+        self.image_type = image_type
+        self.image = image                  # Binary contents of image file
+        self.image_url = image_url
+        self.criteria_url = criteria_url
+        self.json_url = json_url
+        self.verify_key_url = verify_key_url
+        self.key_type = key_type
+        self.privkey_pem = privkey_pem
+        self.pubkey_pem = pubkey_pem
+
+        # Default to no key material so a Badge built without PEMs exposes
+        # priv_key/pub_key as None rather than leaving the attributes undefined
+        # (which turns a later read in the signer/verifier into a confusing raw
+        # AttributeError instead of a clean "no key material" case).
+        self.priv_key: Any = None
+        self.pub_key: Any = None
+
+        # Load whatever key material was supplied. RSA/ECC used to go through
+        # pycryptodome/python-ecdsa; all three families now share cryptography's
+        # unambiguous PEM loaders (the #167 port), producing cryptography key
+        # objects that the JWS layer serialises via keys.key_to_pem.
+        if self.key_type in (KeyType.RSA, KeyType.ECC, KeyType.ED25519):
+            from cryptography.hazmat.primitives.serialization import (
+                load_pem_private_key, load_pem_public_key)
+            label = self.key_type.name
+            if self.pubkey_pem:
+                try:
+                    pub_pem = self.pubkey_pem.encode('utf-8') \
+                        if isinstance(self.pubkey_pem, str) else self.pubkey_pem
+                    self.pub_key = load_pem_public_key(pub_pem)
+                except Exception as exc:
+                    raise PublicKeyReadError(
+                        'Unable to read %s public key: %s' % (label, exc)) from exc
+            if self.privkey_pem:
+                try:
+                    priv_pem = self.privkey_pem.encode('utf-8') \
+                        if isinstance(self.privkey_pem, str) else self.privkey_pem
+                    self.priv_key = load_pem_private_key(priv_pem, password=None)
+                except Exception as exc:
+                    raise PrivateKeyReadError(
+                        'Unable to read %s private key: %s' % (label, exc)) from exc
+        elif self.key_type is not None:
+            # key_type=None is a valid "no key material yet" state; any other
+            # value is an unsupported key type and must fail loudly.
+            raise UnknownKeyType('Unsupported key type: %r' % (self.key_type,))
+
+    @staticmethod
+    def create_from_conf(conf: Any, badge: str) -> 'Badge':
+        """Build a Badge from the ``[badge]`` config section.
+
+        Required for every version: ``name``, ``description``, the signing key
+        pair (``private_key``/``public_key``), ``local_image``, the badge
+        ``image`` URL and the ``badge`` (achievement) URL. ``verify_key`` and
+        ``criteria`` are OpenBadges 1.0 fields and optional here, so an OB 3.0
+        config that omits them issues cleanly.
+
+        Raises the key/image read errors on an unreadable file; a missing
+        required config key raises ``KeyError``, which ``issue_from_conf`` maps
+        to ``IssuanceError`` (the CLI presents it)."""
+        section = conf[badge]
+
+        try:
+            with open(section['private_key'], 'rb') as key:
+                privkey_pem = key.read()
+        except OSError as exc:
+            raise PrivateKeyReadError(
+                'Unable to read private key file %s: %s'
+                % (section['private_key'], exc)) from exc
+
+        try:
+            with open(section['public_key'], 'rb') as key:
+                pubkey_pem = key.read()
+        except OSError as exc:
+            raise PublicKeyReadError(
+                'Unable to read public key file %s: %s'
+                % (section['public_key'], exc)) from exc
+
+        key_type = detect_key_type(pubkey_pem)
+
+        img_path = os.path.join(conf['paths']['base_image'], section['local_image'])
+        if not os.path.isfile(img_path):
+            raise ErrorParsingFile('Badge image file %s does not exist' % img_path)
+        with open(img_path, 'rb') as file:
+            img_content = file.read()
+
+        if img_path.lower().endswith('.svg'):
+            img_type = BadgeImgType.SVG
+        elif img_path.lower().endswith('.png'):
+            img_type = BadgeImgType.PNG
+        else:
+            raise BadgeImgFormatUnsupported(
+                'The image format for %s is not supported' % badge)
+
+        return Badge(ini_name=badge,
+                     name=section['name'],
+                     description=section['description'],
+                     image_type=img_type,
+                     image=img_content,
+                     image_url=section['image'],
+                     criteria_url=section.get('criteria'),      # OB 1.0; optional
+                     json_url=section['badge'],
+                     verify_key_url=section.get('verify_key'),  # OB 1.0; optional
+                     key_type=key_type,
+                     privkey_pem=privkey_pem,
+                     pubkey_pem=pubkey_pem)
+
+    def __str__(self) -> str:
+        return (
+            'INI Name: %s\nName: %s\nDescription: %s\nImage Type: %s\n'
+            'Image Url: %s\nKey Type: %s\nVerify Key: %s\nJSON Url: %s\n'
+            % (self.ini_name, self.name, self.description, self.image_type,
+               self.image_url, self.key_type, self.verify_key_url, self.json_url)
+        )
+
+    def urls_has_problems(self) -> bool:
+        """ Check if urls in Badge are corrects and online """
+
+        error = False
+        checks = [
+            (self.image_url, 'OpenBadge Image'),
+            (self.criteria_url, 'OpenBadge Criteria'),
+            (self.json_url, 'OpenBadge JSon'),
+            (self.verify_key_url, 'OpenBadge Verify key'),
+        ]
+
+        # 'data' is reset for every URL so a previous success can never mask a
+        # later download failure.
+        for url, label in checks:
+            data = None
+            try:
+                data = download_file(url) if url else None
+            except Exception:
+                pass
+            if not data:
+                print('[!] %s at config file is pointing to a wrong url: %s' % (label, url))
+                error = True
+
+        return error

--- a/openbadgeslib/baking.py
+++ b/openbadgeslib/baking.py
@@ -34,6 +34,12 @@ from typing import List, Optional, Tuple, Union, cast
 from defusedxml.minidom import parseString
 from png import Reader, signature as _png_signature
 
+# DecompressionLimitExceeded lives in openbadgeslib.errors (anchored under
+# LibOpenBadgesException). Re-exported explicitly (X as X, so mypy --strict
+# accepts it as a real export) — `baking.DecompressionLimitExceeded` and
+# `from openbadgeslib.baking import DecompressionLimitExceeded` keep working.
+from .errors import DecompressionLimitExceeded as DecompressionLimitExceeded
+
 # OB 2.0 document-format identifiers.
 ITXT_KEYWORD = b'openbadges'
 SVG_ELEMENT = 'openbadges:assertion'
@@ -49,10 +55,6 @@ SVG_NS_OB3 = 'https://purl.imsglobal.org/ob/v3p0'
 # is a few KB; this cap stops a crafted zlib bomb from exhausting memory during
 # extraction (which runs on untrusted input, before any signature check).
 MAX_ITXT_DECOMPRESSED = 256 * 1024
-
-
-class DecompressionLimitExceeded(Exception):
-    """Raised when a compressed iTXt token inflates beyond the allowed size."""
 
 
 def _split_openbadges_itxt(data: bytes, keyword: bytes = ITXT_KEYWORD) -> Optional[bytes]:

--- a/openbadgeslib/config.ini.example
+++ b/openbadgeslib/config.ini.example
@@ -73,6 +73,14 @@ key_type    = RSA
 ; Public base URL of this badge's status lists (<status_base><purpose>.jwt).
 ; Default: ${issuer:publish_url}badge_1/
 ;status_base      = https://openbadges.issuer.badge/issuer/badge_1/
+; STRONGLY RECOMMENDED for revocable badges: freshness window (in days) stamped
+; on each published list as validUntil. Without it a list has NO anti-replay
+; protection — a verifier can't tell a replayed older copy (with fewer
+; revocations) from the current one, so a revoked badge could be resurrected.
+; You MUST republish the lists (openbadges-publish -V 3) before the window
+; lapses; pick a cadence you can sustain (e.g. 7 => weekly). Unset = no bound
+; (offline-friendly, but publishes a loud warning).
+;status_validity_days = 7
 ;alignement  =
 ;tags        =
 ;mail        = ${paths:base}/badge_1_mail.txt

--- a/openbadgeslib/confparser.py
+++ b/openbadgeslib/confparser.py
@@ -23,34 +23,48 @@
 
 from configparser import ConfigParser, ExtendedInterpolation, Error as ConfigParserError
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, TYPE_CHECKING
 import os
 import sys
 import logging
 
 from .errors import ConfigError
 
+if TYPE_CHECKING:
+    from .keys import KeyType
+
 logger = logging.getLogger(__name__)
 
 
+def load_config(config_file: str) -> ConfigParser:
+    """Load a config file as a library call: return the parsed ConfigParser, or
+    raise :class:`ConfigError` if the file is missing, empty, or malformed.
+
+    This is the programmatic entry point — no printing, no ``sys.exit`` — so an
+    integrator can trap the error. CLI tools use :func:`read_config_or_exit`,
+    which presents the message and exits. ``read_conf`` already raises a typed
+    ConfigError for a malformed config (bad INI syntax, an unresolvable
+    ``${...}`` reference, an encoding mismatch, or a missing/empty [paths]
+    base); a missing/empty file returns None, mapped to ConfigError here.
+    """
+    conf = ConfParser(config_file).read_conf()
+    if conf is None:
+        raise ConfigError(
+            'The config file %s does not exist or is empty' % config_file)
+    return conf
+
+
 def read_config_or_exit(config_file: str) -> ConfigParser:
-    """Read a config file for a CLI tool, exiting with a clear message if it is
-    missing, empty, or malformed. Shared by all the console-script entrypoints."""
+    """CLI wrapper over :func:`load_config`: read a config file for a console
+    tool, presenting a clear message and exiting if it is missing, empty, or
+    malformed. Shared by all the console-script entrypoints."""
     try:
-        conf = ConfParser(config_file).read_conf()
+        return load_config(config_file)
     except ConfigError as exc:
-        # read_conf() raises a clean, typed ConfigError for a malformed config
-        # (bad INI syntax, an unresolvable ${...} reference, an encoding
-        # mismatch, or a missing/empty [paths] base). Present it as a controlled
-        # CLI error rather than letting it escape as a raw traceback.
         # ConfigError is a ValueError too, so pre-existing `except ValueError`
         # callers keep working.
         print('[!] %s' % exc)
         sys.exit(-1)
-    if not conf:
-        print('[!] The config file %s does not exist or is empty' % config_file)
-        sys.exit(-1)
-    return conf
 
 
 def resolve_badge_section(conf: ConfigParser, name: str) -> str:
@@ -181,6 +195,91 @@ def ob3_status_config(conf: ConfigParser,
     return OB3StatusConfig(purposes=purposes, size_bits=size_bits,
                            registry_path=registry_path, list_urls=list_urls,
                            validity_days=validity_days)
+
+
+# ── centralized config defaults ──────────────────────────────────────────────
+# One inventory for the accepted-key defaults, so each lives in a single place
+# rather than being re-spelled at every read site. (The status-list defaults —
+# base_status, status_base, validity horizon — are resolved in
+# ob3_status_config / OB3StatusConfig above.)
+DEFAULT_KEY_TYPE = 'RSA'
+
+
+def resolve_key_type(name: Optional[str]) -> 'KeyType':
+    """Map a config ``key_type`` name to a :class:`~openbadgeslib.keys.KeyType`,
+    defaulting to RSA when unset. Accepts RSA / ECC / ED25519 (with EDDSA as an
+    alias), case-insensitively. Raises :class:`ConfigError` for an unknown name.
+
+    The single home for the mapping the keygenerator used to inline.
+    """
+    from .keys import KeyType
+    key = (name or DEFAULT_KEY_TYPE).strip().upper()
+    mapping = {'RSA': KeyType.RSA, 'ECC': KeyType.ECC,
+               'ED25519': KeyType.ED25519, 'EDDSA': KeyType.ED25519}
+    try:
+        return mapping[key]
+    except KeyError:
+        raise ConfigError(
+            "Unknown key_type %r (use RSA, ECC, or ED25519)" % key) from None
+
+
+@dataclass
+class IssuerConfig:
+    """Resolved [issuer] section: the identity fields OB2/OB3 issuance needs,
+    with the OB3 issuer id (did / publish_url / url) resolved once — one home
+    for the [issuer] reads each CLI used to re-spell."""
+    name: str
+    id: str
+    url: Optional[str] = None
+    email: Optional[str] = None
+    publish_url: Optional[str] = None
+    image: Optional[str] = None
+
+
+def issuer_config(conf: ConfigParser) -> IssuerConfig:
+    """Resolve and validate the [issuer] section into a typed IssuerConfig,
+    raising :class:`ConfigError` if the section or its required ``name`` is
+    missing."""
+    if not conf.has_section('issuer'):
+        raise ConfigError("Configuration is missing the [issuer] section")
+    section = conf['issuer']
+    name = (section.get('name') or '').strip()
+    if not name:
+        raise ConfigError("[issuer] is missing the required 'name' key")
+    return IssuerConfig(
+        name=name,
+        id=ob3_issuer_id(conf),
+        url=section.get('url'),
+        email=section.get('email'),
+        publish_url=section.get('publish_url'),
+        image=section.get('image'),
+    )
+
+
+@dataclass
+class BadgeSectionConfig:
+    """Resolved optional badge-section fields with the centralized
+    defaults/fallbacks applied: the criteria narrative (``criteria_narrative``
+    falling back to the OpenBadges 1.0 ``criteria``) and the hosted-assertions
+    base URL. Required keys (name, description, badge) stay direct reads so a
+    missing one still raises ``KeyError`` — the "missing required config key"
+    IssuanceError contract."""
+    section: str
+    criteria_narrative: str
+    hosted_assertions_base: Optional[str] = None
+
+
+def badge_section_config(conf: ConfigParser,
+                         badge_section: str) -> BadgeSectionConfig:
+    """Resolve the optional fields of a badge section with centralized
+    fallbacks."""
+    section = conf[badge_section]
+    return BadgeSectionConfig(
+        section=badge_section,
+        criteria_narrative=section.get('criteria_narrative',
+                                       section.get('criteria', '')),
+        hosted_assertions_base=section.get('hosted_assertions_base'),
+    )
 
 
 class ConfParser():

--- a/openbadgeslib/confparser.py
+++ b/openbadgeslib/confparser.py
@@ -27,6 +27,9 @@ from typing import Dict, List, Optional
 import os
 import sys
 import logging
+
+from .errors import ConfigError
+
 logger = logging.getLogger(__name__)
 
 
@@ -35,11 +38,13 @@ def read_config_or_exit(config_file: str) -> ConfigParser:
     missing, empty, or malformed. Shared by all the console-script entrypoints."""
     try:
         conf = ConfParser(config_file).read_conf()
-    except ValueError as exc:
-        # read_conf() raises a clean, typed ValueError for a malformed config
+    except ConfigError as exc:
+        # read_conf() raises a clean, typed ConfigError for a malformed config
         # (bad INI syntax, an unresolvable ${...} reference, an encoding
         # mismatch, or a missing/empty [paths] base). Present it as a controlled
         # CLI error rather than letting it escape as a raw traceback.
+        # ConfigError is a ValueError too, so pre-existing `except ValueError`
+        # callers keep working.
         print('[!] %s' % exc)
         sys.exit(-1)
     if not conf:
@@ -63,7 +68,7 @@ def ob3_issuer_id(conf: ConfigParser) -> str:
     ``url``), the historical behaviour. ``did = auto`` derives the did:web
     identifier from ``publish_url`` — the DID whose document
     ``openbadges-publish -V 3`` generates — and an explicit ``did:...`` value
-    is used verbatim. Raises ValueError for anything else.
+    is used verbatim. Raises ConfigError for anything else.
     """
     issuer_section = conf['issuer']
     base = issuer_section.get('publish_url', issuer_section.get('url', ''))
@@ -75,7 +80,7 @@ def ob3_issuer_id(conf: ConfigParser) -> str:
         return did_web_from_url(base)
     if did.startswith('did:'):
         return did
-    raise ValueError(
+    raise ConfigError(
         "[issuer] did must be 'auto' or a did:... identifier, got %r" % did)
 
 
@@ -88,12 +93,12 @@ def ob3_proof_format(conf: ConfigParser, badge_section: str) -> str:
     """Return the proof format OB3 credentials of *badge_section* use:
     ``vc-jwt`` (compact JWT-VC, the default) or ``ldp`` (embedded Data
     Integrity proof, cryptosuite eddsa-rdfc-2022 — needs an Ed25519 key and
-    the [ldp] extra). Raises ValueError for anything else.
+    the [ldp] extra). Raises ConfigError for anything else.
     """
     value = (conf[badge_section].get('proof_format') or 'vc-jwt').strip()
     if value in OB3_PROOF_FORMATS:
         return value
-    raise ValueError(
+    raise ConfigError(
         "[%s] proof_format must be one of %s, got %r"
         % (badge_section, ', '.join(OB3_PROOF_FORMATS), value))
 
@@ -114,7 +119,7 @@ def ob3_status_config(conf: ConfigParser,
 
     Returns None when the badge does not opt in (no ``status_lists`` key),
     which callers must treat as "issue without credentialStatus" — the
-    pre-3.1 behaviour. Raises ValueError for an invalid purpose or size.
+    pre-3.1 behaviour. Raises ConfigError for an invalid purpose or size.
     """
     from urllib.parse import urljoin
     from .ob3.status_list import DEFAULT_SIZE_BITS, STATUS_PURPOSES
@@ -126,7 +131,7 @@ def ob3_status_config(conf: ConfigParser,
         if not purpose:
             continue
         if purpose not in STATUS_PURPOSES:
-            raise ValueError(
+            raise ConfigError(
                 "[%s] status_lists: unknown purpose %r (choose from %s)"
                 % (badge_section, purpose, ', '.join(STATUS_PURPOSES)))
         if purpose not in purposes:
@@ -138,14 +143,14 @@ def ob3_status_config(conf: ConfigParser,
         size_bits = int(conf[badge_section].get('status_size_bits',
                                                 str(DEFAULT_SIZE_BITS)))
     except ValueError:
-        raise ValueError("[%s] status_size_bits must be an integer"
-                         % badge_section) from None
+        raise ConfigError("[%s] status_size_bits must be an integer"
+                          % badge_section) from None
     # encode_bitstring requires a positive multiple of 8; validate here so a
     # misconfiguration is a clean config error at issuance/publish load rather
     # than a latent raw ValueError from encode_bitstring at publish time.
     if size_bits <= 0 or size_bits % 8:
-        raise ValueError("[%s] status_size_bits must be a positive multiple "
-                         "of 8" % badge_section)
+        raise ConfigError("[%s] status_size_bits must be a positive multiple "
+                          "of 8" % badge_section)
 
     # Optional validUntil horizon: when set, published status lists carry a
     # validUntil = now + N days, and a verifier rejects a stale copy (replay
@@ -157,11 +162,11 @@ def ob3_status_config(conf: ConfigParser,
         try:
             validity_days = int(validity_raw)
         except ValueError:
-            raise ValueError("[%s] status_validity_days must be an integer"
-                             % badge_section) from None
+            raise ConfigError("[%s] status_validity_days must be an integer"
+                              % badge_section) from None
         if validity_days <= 0:
-            raise ValueError("[%s] status_validity_days must be positive"
-                             % badge_section)
+            raise ConfigError("[%s] status_validity_days must be positive"
+                              % badge_section)
 
     base_status = conf['paths'].get('base_status') or \
         os.path.join(conf['paths']['base'], 'status')
@@ -192,22 +197,22 @@ class ConfParser():
             self.parser.read(self.config_file)
         except UnicodeDecodeError:
             # We should raise an UnicodeDecodeError, but the error message is too cryptic.#
-            raise ValueError("The encoding of the configuration file and the default encoding of "
-                             "the operating system mismatch") from None
+            raise ConfigError("The encoding of the configuration file and the default encoding of "
+                              "the operating system mismatch") from None
         except ConfigParserError as exc:
             # Malformed INI syntax (duplicate section/option, a value line
             # with no section header before it, ...) raises directly from
             # read(), before any interpolation is even attempted.
-            raise ValueError(
+            raise ConfigError(
                 "Configuration file %s has invalid INI syntax: %s" % (self.config_file, exc)) from exc
         try:
             base = self.parser['paths']['base']
         except KeyError:
-            raise ValueError(
+            raise ConfigError(
                 "Configuration file %s is missing the [paths] section or its "
                 "'base' key" % self.config_file) from None
         if not base:
-            raise ValueError(
+            raise ConfigError(
                 "Configuration file %s has an empty [paths] 'base' value" % self.config_file)
 
         # A relative base is resolved against the directory that contains the
@@ -236,7 +241,7 @@ class ConfParser():
             for section in self.parser.sections():
                 dict(self.parser.items(section))
         except ConfigParserError as exc:
-            raise ValueError(
+            raise ConfigError(
                 "Configuration file %s has an invalid value: %s" % (self.config_file, exc)) from exc
 
         return self.parser

--- a/openbadgeslib/errors.py
+++ b/openbadgeslib/errors.py
@@ -23,6 +23,40 @@
 
 
 class LibOpenBadgesException(Exception):
+    """Root of the library exception hierarchy.
+
+    Every error this library raises deliberately derives from this class, so a
+    caller can trap them all with a single ``except LibOpenBadgesException``.
+    The full map (children in their own modules noted inline)::
+
+        LibOpenBadgesException
+        ├── KeyGenExceptions          (alias: KeyGenException)
+        │   ├── GenPrivateKeyError / GenPublicKeyError
+        │   ├── PrivateKeySaveError / PublicKeySaveError
+        │   ├── PrivateKeyReadError / PublicKeyReadError
+        │   └── UnknownKeyType
+        ├── SignerExceptions          (alias: SignerException)
+        │   ├── ErrorSigningFile
+        │   └── UnsupportedAlgorithm  (also ValueError)
+        ├── VerifierExceptions        (alias: VerifierException)
+        │   ├── AssertionFormatIncorrect
+        │   ├── NotIdentityInAssertion
+        │   └── ErrorParsingFile
+        ├── BadgeImgFormatUnsupported
+        ├── ConfigError               (also ValueError)
+        ├── IssuanceError
+        ├── DecompressionLimitExceeded
+        ├── StatusError               (issuer-side revocation)
+        │   └── StatusListFull / UnknownCredential / AmbiguousCredential
+        │       / AlreadyRevoked / AlreadySuspended / NotSuspended
+        │       / RegistryCorrupt
+        ├── OB2VerificationError      (openbadgeslib.ob2.verifier)
+        └── OB3VerificationError      (openbadgeslib.ob3.verifier)
+
+    ``ConfigError`` and ``UnsupportedAlgorithm`` also inherit ``ValueError`` so
+    that code (and tests) catching the historical ``ValueError`` keep working
+    while the errors are now reachable through the library root too.
+    """
     pass
 
 
@@ -39,6 +73,13 @@ class SignerExceptions(LibOpenBadgesException):
 
 class VerifierExceptions(LibOpenBadgesException):
     pass
+
+
+# Singular aliases for the plural base names, so callers can name a family in
+# the natural singular ("except SignerException") without the historical typo.
+KeyGenException = KeyGenExceptions
+SignerException = SignerExceptions
+VerifierException = VerifierExceptions
 
 
 """ User-defined Exceptions """
@@ -79,6 +120,15 @@ class ErrorSigningFile(SignerExceptions):
     pass
 
 
+class UnsupportedAlgorithm(SignerExceptions, ValueError):
+    """A signer was asked for a JWS algorithm it does not support.
+
+    Also a ``ValueError`` for backward compatibility with callers that trap the
+    historical bare ``ValueError`` from the signer constructors.
+    """
+    pass
+
+
 """ Verifier Exceptions """
 
 
@@ -98,6 +148,40 @@ class ErrorParsingFile(VerifierExceptions):
 
 
 class BadgeImgFormatUnsupported(LibOpenBadgesException):
+    pass
+
+
+""" Configuration Exceptions """
+
+
+class ConfigError(LibOpenBadgesException, ValueError):
+    """A configuration file is missing, malformed, or has an invalid value.
+
+    Also a ``ValueError`` for backward compatibility: the config helpers raised
+    a bare ``ValueError`` historically, and ``read_config_or_exit`` (plus the
+    tests) still catch that. Anchoring it under ``LibOpenBadgesException`` too
+    lets a caller trap every library error with one ``except``.
+    """
+    pass
+
+
+""" Issuance Exceptions """
+
+
+class IssuanceError(LibOpenBadgesException):
+    """Raised when a badge cannot be issued (bad config, unsupported key, a
+    policy violation such as a did:key issuer that is not the signing key, or a
+    status-registry failure). The CLI catches it and presents it; a library
+    caller handles it programmatically. Messages carry no ``[!]`` prefix — the
+    presentation layer adds one."""
+    pass
+
+
+""" Baking Exceptions """
+
+
+class DecompressionLimitExceeded(LibOpenBadgesException):
+    """Raised when a compressed iTXt token inflates beyond the allowed size."""
     pass
 
 

--- a/openbadgeslib/issue.py
+++ b/openbadgeslib/issue.py
@@ -50,7 +50,7 @@ import uuid
 
 from dataclasses import dataclass, field
 from datetime import datetime, timezone, timedelta
-from typing import Any, List, NamedTuple, Optional
+from typing import Any, List, NamedTuple, Optional, TYPE_CHECKING
 from urllib.parse import urljoin
 
 from .errors import (BadgeImgFormatUnsupported, ErrorSigningFile,
@@ -61,6 +61,14 @@ from .errors import IssuanceError as IssuanceError
 from .keys import KeyType, alg_for_key_type, detect_key_type
 from .badge_model import Badge, BadgeImgType
 from .util import normalize_recipient_id
+
+if TYPE_CHECKING:
+    # Boundary types for SignResult / _Ob3Context. Imported only for typing
+    # (zero runtime cost, correct autocompletion and pdoc) — the modules are
+    # otherwise resolved lazily inside the issuance functions.
+    from .ob2 import Assertion
+    from .ob3 import Achievement, Issuer, OpenBadgeCredential
+    from .confparser import OB3StatusConfig
 
 logger = logging.getLogger(__name__)
 
@@ -83,8 +91,8 @@ class SignResult:
     jti: Optional[str] = None           # OB3 credential id
     status_index: Optional[int] = None  # OB3 status-list index (revocable badges)
     proof_format: Optional[str] = None  # OB3: 'vc-jwt' | 'ldp'
-    credential: Optional[Any] = None    # OB3 OpenBadgeCredential
-    assertion: Optional[Any] = None     # OB2 Assertion
+    credential: Optional['OpenBadgeCredential'] = None    # OB3
+    assertion: Optional['Assertion'] = None               # OB2
     assertion_id: Optional[str] = None  # OB2 hosted assertion URL
     hosted_json: Optional[str] = None   # OB2 hosted: assertion JSON to publish
     # Informational hints the CLI prints (without the '[!]'/'[i]' prefix), e.g.
@@ -303,10 +311,10 @@ def _issue_ob2(conf: configparser.ConfigParser, badge: str, recipient: str,
 class _Ob3Context(NamedTuple):
     """The per-badge OB3 config resolved once, shared by every recipient in a
     batch (issuer/achievement are identical; only the subject differs)."""
-    issuer: Any
-    achievement: Any
+    issuer: 'Issuer'
+    achievement: 'Achievement'
     issuer_id: str
-    status_conf: Any
+    status_conf: Optional['OB3StatusConfig']
     proof_format: str
     key_type: KeyType
 

--- a/openbadgeslib/issue.py
+++ b/openbadgeslib/issue.py
@@ -243,7 +243,8 @@ def _issue_ob2(conf: configparser.ConfigParser, badge: str, recipient: str,
     recipient_obj = IdentityObject.create(recipient, salt=salt)
 
     if hosted:
-        hosted_base = badge_section.get('hosted_assertions_base')
+        from .confparser import badge_section_config
+        hosted_base = badge_section_config(conf, badge).hosted_assertions_base
         if not hosted_base:
             raise IssuanceError(
                 "-V 2 -H (hosted) requires 'hosted_assertions_base' in the "
@@ -317,32 +318,34 @@ def _ob3_setup(conf: configparser.ConfigParser, badge: str, badge_obj: Badge,
     config, the effective proof format and the signing key type. Raises
     IssuanceError on any config problem."""
     from .ob3 import Issuer, Achievement
-    from .confparser import ob3_issuer_id, ob3_proof_format, ob3_status_config
+    from .confparser import (ob3_proof_format, ob3_status_config,
+                             issuer_config, badge_section_config)
 
     # A missing [issuer]/[badge] key raises KeyError and the confparser helpers
-    # raise ValueError; both are config problems, so surface them as the
-    # documented IssuanceError rather than a raw traceback out of the CLI/API.
+    # raise ConfigError (a ValueError); both are config problems, so surface them
+    # as the documented IssuanceError rather than a raw traceback out of the
+    # CLI/API. IssuerConfig / BadgeSectionConfig resolve the sections and their
+    # defaults once (issuer id, criteria_narrative->criteria fallback).
     try:
-        issuer_id = ob3_issuer_id(conf)
         status_conf = ob3_status_config(conf, badge)
         proof_format = proof_format or ob3_proof_format(conf, badge)
 
-        issuer_section = conf['issuer']
+        issuer_cfg = issuer_config(conf)
+        issuer_id = issuer_cfg.id
         issuer = Issuer(
-            id=issuer_id,
-            name=issuer_section['name'],
-            url=issuer_section.get('url'),
-            email=issuer_section.get('email'),
+            id=issuer_cfg.id,
+            name=issuer_cfg.name,
+            url=issuer_cfg.url,
+            email=issuer_cfg.email,
         )
 
         badge_section = conf[badge]
-        criteria_narrative = badge_section.get('criteria_narrative',
-                                               badge_section.get('criteria', ''))
+        bsc = badge_section_config(conf, badge)
         achievement = Achievement(
             id=badge_section['badge'],
             name=badge_section['name'],
             description=badge_section['description'],
-            criteria_narrative=criteria_narrative,
+            criteria_narrative=bsc.criteria_narrative,
             image_url=badge_section.get('image'),
         )
     except ValueError as exc:

--- a/openbadgeslib/issue.py
+++ b/openbadgeslib/issue.py
@@ -53,9 +53,10 @@ from datetime import datetime, timezone, timedelta
 from typing import Any, List, NamedTuple, Optional
 from urllib.parse import urljoin
 
-from .errors import BadgeImgFormatUnsupported, ErrorSigningFile, StatusError
+from .errors import (BadgeImgFormatUnsupported, ErrorSigningFile,
+                     LibOpenBadgesException, StatusError)
 from .keys import KeyType, alg_for_key_type, detect_key_type
-from .ob1.badge import Badge, BadgeImgType
+from .badge_model import Badge, BadgeImgType
 from .util import normalize_recipient_id
 
 logger = logging.getLogger(__name__)
@@ -126,6 +127,19 @@ def output_basename(badge: str, recipient: str,
     raise BadgeImgFormatUnsupported('Unsupported image type: %r' % (image_type,))
 
 
+def _badge_from_conf(conf: configparser.ConfigParser, badge: str) -> Badge:
+    """Build the Badge config model, mapping a missing required config key or an
+    unreadable key/image to :class:`IssuanceError` — so the issue_* entry points
+    honour their documented contract instead of leaking a raw ``KeyError`` (e.g.
+    an OB3 config with no OB1 ``verify_key``) out of ``Badge.create_from_conf``."""
+    try:
+        return Badge.create_from_conf(conf, badge)
+    except KeyError as exc:
+        raise IssuanceError('missing required config key %s' % exc) from exc
+    except LibOpenBadgesException as exc:
+        raise IssuanceError(str(exc)) from exc
+
+
 def issue_from_conf(conf: configparser.ConfigParser, badge: str, recipient: str,
                     ob_version: str = '3', *, evidence: Optional[str] = None,
                     expires: Optional[int] = None, hosted: bool = False,
@@ -137,7 +151,7 @@ def issue_from_conf(conf: configparser.ConfigParser, badge: str, recipient: str,
     overrides the OB3 badge's ``proof_format`` ('vc-jwt' | 'ldp'). Returns a
     :class:`SignResult`; raises :class:`IssuanceError`. Supports OB 2.0 and
     3.0 (OB 1.0 is issued via the CLI only)."""
-    badge_obj = Badge.create_from_conf(conf, badge)
+    badge_obj = _badge_from_conf(conf, badge)
     return issue_badge(conf, badge, recipient, badge_obj, ob_version,
                        evidence=evidence, expires=expires, hosted=hosted,
                        proof_format=proof_format)
@@ -179,7 +193,7 @@ def issue_batch_from_conf(conf: configparser.ConfigParser, badge: str,
     section, or the status list lacking room for the whole batch) raises
     :class:`IssuanceError` — the transaction is atomic, so nothing is issued.
     OpenBadges 1.0 is single-recipient only (CLI)."""
-    badge_obj = Badge.create_from_conf(conf, badge)
+    badge_obj = _badge_from_conf(conf, badge)
     return issue_batch(conf, badge, recipients, badge_obj, ob_version,
                        evidence=evidence, expires=expires, hosted=hosted,
                        proof_format=proof_format)

--- a/openbadgeslib/issue.py
+++ b/openbadgeslib/issue.py
@@ -55,19 +55,19 @@ from urllib.parse import urljoin
 
 from .errors import (BadgeImgFormatUnsupported, ErrorSigningFile,
                      LibOpenBadgesException, StatusError)
+# Re-export explicitly (X as X) so mypy --strict treats the historical
+# `from openbadgeslib.issue import IssuanceError` path as a real public export.
+from .errors import IssuanceError as IssuanceError
 from .keys import KeyType, alg_for_key_type, detect_key_type
 from .badge_model import Badge, BadgeImgType
 from .util import normalize_recipient_id
 
 logger = logging.getLogger(__name__)
 
-
-class IssuanceError(Exception):
-    """Raised when a badge cannot be issued (bad config, unsupported key, a
-    policy violation such as a did:key issuer that is not the signing key, or a
-    status-registry failure). The CLI catches it and presents it; a library
-    caller handles it programmatically. Messages carry no ``[!]`` prefix — the
-    presentation layer adds one."""
+# IssuanceError now lives in openbadgeslib.errors (anchored under
+# LibOpenBadgesException, so `except LibOpenBadgesException` catches it).
+# Re-exported here so `from openbadgeslib.issue import IssuanceError` — the
+# historical import path — keeps working.
 
 
 @dataclass

--- a/openbadgeslib/mail.py
+++ b/openbadgeslib/mail.py
@@ -30,7 +30,7 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.utils import formatdate
 from email.header import Header
-from .ob1.badge import BadgeImgType  # leaf import: avoids the ob1 deprecation warning
+from .badge_model import BadgeImgType   # version-neutral model (was ob1.badge)
 from .errors import BadgeImgFormatUnsupported
 
 

--- a/openbadgeslib/ob1/badge.py
+++ b/openbadgeslib/ob1/badge.py
@@ -21,17 +21,24 @@
         License along with this library.
 """
 
-import os
 from enum import Enum
 from typing import Any, Optional, Union, cast
 
-from ..keys import KeyType, detect_key_type
+from ..keys import detect_key_type
 from ..errors import (BadgeImgFormatUnsupported, AssertionFormatIncorrect,
-                      ErrorParsingFile, UnknownKeyType, PrivateKeyReadError,
-                      PublicKeyReadError)
+                      ErrorParsingFile)
 from .._jws import utils as jws_utils
 from ..util import hash_email, download_file
 from .. import baking
+# The version-neutral model lives in badge_model now; re-exported here (via
+# __all__) so ob1.badge and the openbadgeslib.badge shim keep exposing them.
+from ..badge_model import Badge, BadgeImgType
+
+__all__ = [
+    'BadgeStatus', 'BadgeImgType', 'BadgeType',
+    'Assertion', 'Badge', 'BadgeSigned',
+    'extract_svg_assertion', 'extract_png_assertion',
+]
 
 
 class BadgeStatus(Enum):
@@ -41,11 +48,6 @@ class BadgeStatus(Enum):
     REVOKED = 4
     IDENTITY_ERROR = 5
     NONE = 6  # unset sentinel (VerifyInfo default); never returned by a real check
-
-
-class BadgeImgType(Enum):
-    SVG = 0
-    PNG = 1
 
 
 class BadgeType(Enum):
@@ -88,152 +90,6 @@ class Assertion():
 
     def __str__(self) -> str:
         return 'Header: %s\nBody: %s\nSignature: %s' % (self.header, self.body, self.signature)
-
-
-class Badge():
-    def __init__(self, ini_name: Optional[str] = None, name: Optional[str] = None,
-                 description: Optional[str] = None, image_type: Optional[BadgeImgType] = None,
-                 image: Optional[bytes] = None, image_url: Optional[str] = None,
-                 criteria_url: Optional[str] = None, json_url: Optional[str] = None,
-                 verify_key_url: Optional[str] = None, key_type: Optional[KeyType] = None,
-                 privkey_pem: Optional[Union[str, bytes]] = None,
-                 pubkey_pem: Optional[Union[str, bytes]] = None) -> None:
-
-        self.ini_name = ini_name
-        self.name = name
-        self.description = description
-        self.image_type = image_type
-        self.image = image                  # Binary contents of image file
-        self.image_url = image_url
-        self.criteria_url = criteria_url
-        self.json_url = json_url
-        self.verify_key_url = verify_key_url
-        self.key_type = key_type
-        self.privkey_pem = privkey_pem
-        self.pubkey_pem = pubkey_pem
-
-        # Default to no key material so a Badge built without PEMs exposes
-        # priv_key/pub_key as None rather than leaving the attributes undefined
-        # (which turns a later read in the signer/verifier into a confusing raw
-        # AttributeError instead of a clean "no key material" case).
-        self.priv_key: Any = None
-        self.pub_key: Any = None
-
-        # Load whatever key material was supplied. RSA/ECC used to go through
-        # pycryptodome/python-ecdsa; all three families now share cryptography's
-        # unambiguous PEM loaders (the #167 port), producing cryptography key
-        # objects that the JWS layer serialises via keys.key_to_pem.
-        if self.key_type in (KeyType.RSA, KeyType.ECC, KeyType.ED25519):
-            from cryptography.hazmat.primitives.serialization import (
-                load_pem_private_key, load_pem_public_key)
-            label = self.key_type.name
-            if self.pubkey_pem:
-                try:
-                    pub_pem = self.pubkey_pem.encode('utf-8') \
-                        if isinstance(self.pubkey_pem, str) else self.pubkey_pem
-                    self.pub_key = load_pem_public_key(pub_pem)
-                except Exception as exc:
-                    raise PublicKeyReadError(
-                        'Unable to read %s public key: %s' % (label, exc)) from exc
-            if self.privkey_pem:
-                try:
-                    priv_pem = self.privkey_pem.encode('utf-8') \
-                        if isinstance(self.privkey_pem, str) else self.privkey_pem
-                    self.priv_key = load_pem_private_key(priv_pem, password=None)
-                except Exception as exc:
-                    raise PrivateKeyReadError(
-                        'Unable to read %s private key: %s' % (label, exc)) from exc
-        elif self.key_type is not None:
-            # key_type=None is a valid "no key material yet" state; any other
-            # value is an unsupported key type and must fail loudly.
-            raise UnknownKeyType('Unsupported key type: %r' % (self.key_type,))
-
-    @staticmethod
-    def create_from_conf(conf: Any, badge: str) -> 'Badge':
-        """ Create a Badge Object reading params from config.ini """
-
-        """ Keys """
-        try:
-            with open(conf[badge]['private_key'], 'rb') as key:
-                privkey_pem = key.read()
-        except OSError as exc:
-            raise PrivateKeyReadError(
-                'Unable to read private key file %s: %s' % (conf[badge]['private_key'], exc)) from exc
-
-        try:
-            with open(conf[badge]['public_key'], 'rb') as key:
-                pubkey_pem = key.read()
-        except OSError as exc:
-            raise PublicKeyReadError(
-                'Unable to read public key file %s: %s' % (conf[badge]['public_key'], exc)) from exc
-
-        key_type = detect_key_type(pubkey_pem)
-
-        """ Image """
-        img_path = os.path.join(conf['paths']['base_image'], conf[badge]['local_image'])
-
-        if not os.path.isfile(img_path):
-            print('Badge file %s NOT exists.' % img_path)
-            raise IOError
-
-        with open(img_path, 'rb') as file:
-            img_content = file.read()
-
-        if img_path.lower().endswith('.svg'):
-            img_type = BadgeImgType.SVG
-        elif img_path.lower().endswith('.png'):
-            img_type = BadgeImgType.PNG
-        else:
-            raise BadgeImgFormatUnsupported('The image format for %s is not supported' % badge)
-
-        """ Object Creation """
-        return Badge(ini_name=badge,
-                     name=conf[badge]['name'],
-                     description=conf[badge]['description'],
-                     image_type=img_type,
-                     image=img_content,
-                     image_url=conf[badge]['image'],
-                     criteria_url=conf[badge]['criteria'],
-                     json_url=conf[badge]['badge'],
-                     verify_key_url=conf[badge]['verify_key'],
-                     key_type=key_type,
-                     privkey_pem=privkey_pem,
-                     pubkey_pem=pubkey_pem)
-
-        return None
-
-    def __str__(self) -> str:
-        return (
-            'INI Name: %s\nName: %s\nDescription: %s\nImage Type: %s\n'
-            'Image Url: %s\nKey Type: %s\nVerify Key: %s\nJSON Url: %s\n'
-            % (self.ini_name, self.name, self.description, self.image_type,
-               self.image_url, self.key_type, self.verify_key_url, self.json_url)
-        )
-
-    def urls_has_problems(self) -> bool:
-        """ Check if urls in Badge are corrects and online """
-
-        error = False
-        checks = [
-            (self.image_url, 'OpenBadge Image'),
-            (self.criteria_url, 'OpenBadge Criteria'),
-            (self.json_url, 'OpenBadge JSon'),
-            (self.verify_key_url, 'OpenBadge Verify key'),
-        ]
-
-        # 'data' is reset for every URL so a previous success can never mask a
-        # later download failure.
-        for url, label in checks:
-            data = None
-            try:
-                data = download_file(url) if url else None
-            except Exception:
-                pass
-            if not data:
-                print('[!] %s at config file is pointing to a wrong url: %s' % (label, url))
-                error = True
-
-        return error
 
 
 class BadgeSigned():

--- a/openbadgeslib/ob2/models.py
+++ b/openbadgeslib/ob2/models.py
@@ -35,37 +35,19 @@ from datetime import datetime, timezone
 from typing import Any, List, Optional, Union
 
 from ..util import hash_email
+# Shared JSON helpers live in openbadgeslib._jsonmodel now (deduplicated with
+# ob3.credential, which had the correct naive=>UTC _iso semantics). Re-exported
+# (X as X) so ob2.verifier's `from .models import _parse_iso` keeps working.
+from .._jsonmodel import (
+    _iso as _iso, _parse_iso as _parse_iso,
+    _as_dict as _as_dict, _require as _require,
+)
 
 OB2_CONTEXT = "https://w3id.org/openbadges/v2"
 
 # JWS signature algorithms this package can emit/accept, matching the key types
 # openbadges-keygenerator produces (RSA → RS*, ECC P-256 → ES*, Ed25519 → EdDSA).
 _SUPPORTED_ALGORITHMS = {'RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512', 'EdDSA'}
-
-
-# ── date helpers ─────────────────────────────────────────────────────────────
-
-def _iso(dt: datetime) -> str:
-    """Return a datetime as an ISO 8601 string with a ``Z`` UTC suffix."""
-    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
-def _parse_iso(value: Any, where: str) -> datetime:
-    """Parse an ISO 8601 timestamp (with a UTC offset or trailing ``Z``).
-
-    OB 2.0 requires string ISO 8601 timestamps with a time-zone indicator;
-    a bare Unix timestamp (the legacy OB 1.0 shape) is deliberately rejected
-    here so the strict verifier does not silently accept legacy assertions.
-    """
-    if not isinstance(value, str):
-        raise ValueError("%s must be an ISO 8601 string, got %r" % (where, value))
-    try:
-        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError as exc:
-        raise ValueError("invalid ISO 8601 date in %s: %r" % (where, value)) from exc
-    if dt.tzinfo is None:
-        raise ValueError("%s is missing a UTC offset: %r" % (where, value))
-    return dt
 
 
 # ── JSON-LD validation helpers ───────────────────────────────────────────────
@@ -93,22 +75,6 @@ def _validate_type(value: Any, expected: str, where: str) -> None:
         raise ValueError("%s.type must be a string or array" % where)
     if expected not in types:
         raise ValueError("%s.type must include %r, got %r" % (where, expected, value))
-
-
-def _as_dict(value: Any, where: str) -> dict[str, Any]:
-    if not isinstance(value, dict):
-        raise ValueError("%s must be a JSON object" % where)
-    return value
-
-
-def _require(data: dict[str, Any], key: str, where: str) -> str:
-    """Return ``data[key]`` as a non-empty string, else raise a clear error."""
-    value = data.get(key)
-    if value is None or value == "":
-        raise ValueError("missing required field %s.%s" % (where, key))
-    if not isinstance(value, str):
-        raise ValueError("field %s.%s must be a string" % (where, key))
-    return value
 
 
 def _iri_or_none(value: Any) -> Optional[str]:

--- a/openbadgeslib/ob2/signer.py
+++ b/openbadgeslib/ob2/signer.py
@@ -25,7 +25,7 @@ from typing import Any
 from .models import Assertion, _SUPPORTED_ALGORITHMS
 from ..util import __version__
 from ..keys import key_to_pem
-from ..errors import ErrorSigningFile
+from ..errors import ErrorSigningFile, UnsupportedAlgorithm
 from .._jws import sign as jws_sign
 from .._jws import utils as jws_utils
 from .. import baking
@@ -49,7 +49,7 @@ class OB2Signer:
 
     def __init__(self, privkey_pem: Any, algorithm: str = 'RS256') -> None:
         if algorithm not in _SUPPORTED_ALGORITHMS:
-            raise ValueError(
+            raise UnsupportedAlgorithm(
                 "Unsupported algorithm %r. Choose from: %s"
                 % (algorithm, sorted(_SUPPORTED_ALGORITHMS)))
         self.privkey_pem = key_to_pem(privkey_pem)

--- a/openbadgeslib/ob3/__init__.py
+++ b/openbadgeslib/ob3/__init__.py
@@ -36,8 +36,13 @@ from .did import (build_did_document, did_key_from_pem, did_web_from_url,
 from .publish import (AmbiguousCredential, CredentialNotFound, PublishError,
                       PublishResult, StatusOperation, publish_ob3)
 from ..util import CachingDownloader
+# The EUDI SD-JWT VC track (openvc-core, the [eudi] extra). Re-exported as a
+# submodule — its heavy imports are lazy (_require_openvc), so this stays cheap —
+# so `openbadgeslib.ob3.eudi` is reachable without a deep import path.
+from . import eudi  # noqa: F401
 
 __all__ = [
+    'eudi',
     'Achievement',
     'AmbiguousCredential',
     'CachingDownloader',

--- a/openbadgeslib/ob3/credential.py
+++ b/openbadgeslib/ob3/credential.py
@@ -26,6 +26,14 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, List, Optional
 
+# Shared JSON helpers live in openbadgeslib._jsonmodel now (deduplicated with
+# ob2.models). Re-exported (X as X) so the ob3 modules and tests that do
+# `from .credential import _iso, _parse_iso` keep working.
+from .._jsonmodel import (
+    _iso as _iso, _parse_iso as _parse_iso,
+    _as_dict as _as_dict, _require as _require,
+)
+
 _VC2_CONTEXT = "https://www.w3.org/ns/credentials/v2"
 
 OB3_CONTEXT = [
@@ -63,18 +71,6 @@ def _validate_context(ctx: Any) -> None:
     if not (isinstance(ctx[1], str) and _OB_CONTEXT_RE.match(ctx[1])):
         raise ValueError(
             "@context[1] must be the OB v3p0 context URI, got %r" % (ctx[1],))
-
-
-def _iso(dt: datetime) -> str:
-    """Return a datetime as an ISO 8601 string with Z suffix.
-
-    A naive datetime is assumed to be UTC (matching status_registry._iso_z),
-    not local time — so validFrom/validUntil never silently shift by the host's
-    offset and stay consistent with the nbf/exp JWT claims.
-    """
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 @dataclass
@@ -650,13 +646,6 @@ class OpenBadgeCredential:
         return credential
 
 
-def _as_dict(value: Any, where: str) -> dict[str, Any]:
-    """Return value if it is a dict, else raise a clear ValueError."""
-    if not isinstance(value, dict):
-        raise ValueError("%s must be a JSON object" % where)
-    return value
-
-
 def _as_dict_or_empty(value: Any) -> dict[str, Any]:
     """Return value if it is a dict, else an empty dict (optional sub-objects)."""
     return value if isinstance(value, dict) else {}
@@ -693,19 +682,6 @@ def _alignment_list(value: Any) -> List["Alignment"]:
     return []
 
 
-def _require(data: dict[str, Any], key: str, where: str) -> str:
-    """Return data[key] as a string, raising a clear ValueError if missing,
-    empty, or not a string. All fields validated here (id/name) are identifiers
-    consumed as strings downstream (e.g. recipient binding calls .lower()), so a
-    non-string value must be rejected rather than crash later."""
-    value = data.get(key)
-    if value is None or value == "":
-        raise ValueError("missing required field %s.%s" % (where, key))
-    if not isinstance(value, str):
-        raise ValueError("field %s.%s must be a string" % (where, key))
-    return value
-
-
 def _parse_date(value: Any, where: str) -> datetime:
     """Parse an ISO 8601 date, raising a clear ValueError naming the field."""
     try:
@@ -713,14 +689,3 @@ def _parse_date(value: Any, where: str) -> datetime:
     except (ValueError, TypeError, AttributeError) as exc:
         raise ValueError(
             "invalid ISO 8601 date in %s: %r" % (where, value)) from exc
-
-
-def _parse_iso(s: str) -> datetime:
-    """Parse an ISO 8601 date string, handling trailing Z."""
-    dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
-    if dt.tzinfo is None:
-        # A date-time with no UTC/offset suffix is valid ISO 8601, but verify()
-        # always compares against an aware datetime.now(timezone.utc) — accept
-        # only unambiguously-anchored timestamps.
-        raise ValueError("date is missing a UTC offset: %r" % s)
-    return dt

--- a/openbadgeslib/ob3/eudi.py
+++ b/openbadgeslib/ob3/eudi.py
@@ -100,9 +100,15 @@ def badge_to_sd_jwt_claims(credential: OpenBadgeCredential) -> dict[str, Any]:
     """Map an OpenBadgeCredential to a flat SD-JWT VC claim set.
 
     The ``achievement`` (the badge itself) is always disclosed; the recipient's
-    identity is kept under ``credentialSubject`` so it can be made selectively
-    disclosable (``DEFAULT_DISCLOSABLE``). ``iss``/``vct``/``iat`` are set by the
-    suite at issuance.
+    identity is kept under ``credentialSubject`` — both ``id`` and the hashed
+    ``identifier`` entries — so it can be made selectively disclosable
+    (``DEFAULT_DISCLOSABLE`` covers the whole ``credentialSubject``).
+    ``iss``/``vct``/``iat`` are set by the suite at issuance.
+
+    ``credentialStatus`` is NOT mapped: SD-JWT VC status carriage/checking is not
+    wired yet, so an SD-JWT VC badge is currently irrevocable. A credential that
+    carries a status is rejected at issuance by :func:`issue_badge_sd_jwt` rather
+    than silently dropped here.
     """
     vc = credential.to_vc()
     subject = vc.get("credentialSubject", {})
@@ -112,9 +118,18 @@ def badge_to_sd_jwt_claims(credential: OpenBadgeCredential) -> dict[str, Any]:
         "achievement": subject.get("achievement"),
         "validFrom": vc.get("validFrom"),
     }
+    # Keep the recipient's identity: credentialSubject.id AND the hashed
+    # identifier entries — a badge whose subject travelled via identifier (no id)
+    # would otherwise end up with no checkable recipient.
+    subject_claims: dict[str, Any] = {}
     recipient = subject.get("id")
     if recipient is not None:
-        claims["credentialSubject"] = {"id": recipient}
+        subject_claims["id"] = recipient
+    identifier = subject.get("identifier")
+    if identifier:
+        subject_claims["identifier"] = identifier
+    if subject_claims:
+        claims["credentialSubject"] = subject_claims
     if "validUntil" in vc:
         claims["validUntil"] = vc["validUntil"]
     return claims
@@ -211,7 +226,21 @@ def issue_badge_sd_jwt(
     Trusted List trust). The leaf's key must be *privkey_pem* and the issuer id
     must be in the leaf SAN, or verification fails closed. Needs openvc-core
     >=1.18. This closes the loop with the verify-side x5c support (#178).
+
+    IRREVOCABLE: SD-JWT VC status carriage/checking is not wired yet, so an
+    SD-JWT VC badge cannot be revoked. Rather than silently drop a credential's
+    ``credentialStatus`` (which would issue a badge the issuer believes is
+    revocable), this raises :class:`EudiError` if the credential carries one.
+    Issue a revocable OB 3.0 credential with the JWT-VC or LDP proof format
+    instead (#226).
     """
+    if credential.credential_status:
+        raise EudiError(
+            "this credential carries a credentialStatus (revocation/suspension) "
+            "but SD-JWT VC issuance cannot carry status yet, so the badge would "
+            "be irrevocable. Refusing to silently drop it — issue it without a "
+            "status list, or use the JWT-VC / LDP proof format for a revocable "
+            "OB 3.0 credential.")
     _, _, _, SdJwtVcProofSuite = _require_openvc()
     signing_key = _signing_key(privkey_pem, kid or ("%s#key-1" % credential.issuer.id))
     claims = badge_to_sd_jwt_claims(credential)
@@ -244,6 +273,11 @@ def verify_badge_sd_jwt(
     ``.key_bound``, ``.confirmation``). Raises :class:`EudiError` on any failure.
     Pass *audience*/*nonce* (and ``require_key_binding=True``) to check a Key
     Binding JWT from a holder presentation.
+
+    NOTE: revocation status is NOT checked (``require_status=False`` on both
+    paths). SD-JWT VC badges are issued without a ``credentialStatus``
+    (:func:`issue_badge_sd_jwt` rejects one), so there is nothing to check — an
+    SD-JWT VC badge is currently irrevocable (#226).
 
     Trust comes from exactly one of two sources:
 

--- a/openbadgeslib/ob3/publish.py
+++ b/openbadgeslib/ob3/publish.py
@@ -120,8 +120,10 @@ class PublishResult:
     ``<purpose>.jwt`` and ``verify.pem``, optional Type Metadata). ``did_skipped``
     / ``status_skipped`` are ``(badge, reason)`` for badges left out of did.json
     or whose status lists could not be regenerated; ``no_status_config`` lists
-    badges without ``status_lists``. ``status_operation`` is set when a
-    revoke/suspend/unsuspend was applied.
+    badges without ``status_lists``. ``no_validity_bound`` lists revocable badges
+    whose status lists were published with no ``validUntil`` (no anti-replay
+    freshness — set ``status_validity_days`` and republish regularly).
+    ``status_operation`` is set when a revoke/suspend/unsuspend was applied.
     """
     did: str
     publish_url: str
@@ -131,6 +133,7 @@ class PublishResult:
     did_skipped: List[Tuple[str, str]] = field(default_factory=list)
     status_skipped: List[Tuple[str, str]] = field(default_factory=list)
     no_status_config: List[str] = field(default_factory=list)
+    no_validity_bound: List[str] = field(default_factory=list)
     type_metadata: Optional[TypeMetadata] = None
     live_check: Optional[List[LiveArtifact]] = None
 
@@ -362,6 +365,7 @@ def publish_ob3(conf: configparser.ConfigParser, output: str, *,
     did_skipped: List[Tuple[str, str]] = []
     status_skipped: List[Tuple[str, str]] = []
     no_status_config: List[str] = []
+    no_validity_bound: List[str] = []
     files_written: List[str] = []
     type_metadata: Optional[TypeMetadata] = None
 
@@ -410,6 +414,12 @@ def publish_ob3(conf: configparser.ConfigParser, output: str, *,
                 if status_conf.validity_days is not None:
                     valid_until = (datetime.now(tz=timezone.utc)
                                    + timedelta(days=status_conf.validity_days))
+                else:
+                    # No validUntil => the published list has no anti-replay
+                    # freshness: a verifier can't tell a stale/replayed copy
+                    # (with fewer revocations) from the current one. Flag it
+                    # loudly so the issuer sets status_validity_days.
+                    no_validity_bound.append(name)
 
                 badge_dir = os.path.join(output, name)
                 os.makedirs(badge_dir, exist_ok=True)
@@ -440,5 +450,6 @@ def publish_ob3(conf: configparser.ConfigParser, output: str, *,
         did=did, publish_url=publish_url, output=output,
         files_written=files_written, status_operation=status_operation,
         did_skipped=did_skipped, status_skipped=status_skipped,
-        no_status_config=no_status_config, type_metadata=type_metadata,
+        no_status_config=no_status_config,
+        no_validity_bound=no_validity_bound, type_metadata=type_metadata,
         live_check=live_check)

--- a/openbadgeslib/ob3/publish.py
+++ b/openbadgeslib/ob3/publish.py
@@ -431,11 +431,15 @@ def publish_ob3(conf: configparser.ConfigParser, output: str, *,
                         indices, registry.size_bits, valid_until=valid_until)
                     token = sign_status_list_credential(vc, priv_pem, algorithm)
                     _write_atomic(os.path.join(badge_dir, purpose + '.jwt'), token)
-                    files_written.append(os.path.join(name, purpose + '.jwt'))
+                    # files_written entries are output-relative URL paths (they
+                    # map onto publish_url via urljoin and back to a file via
+                    # rel.replace('/', os.sep) in _check_live) — always '/', never
+                    # os.sep, or a Windows backslash would break both.
+                    files_written.append('%s/%s.jwt' % (name, purpose))
 
                 shutil.copyfile(conf[name]['public_key'],
                                 os.path.join(badge_dir, 'verify.pem'))
-                files_written.append(os.path.join(name, 'verify.pem'))
+                files_written.append('%s/verify.pem' % name)
             except (StatusError, OSError, KeyError, LibOpenBadgesException) as exc:
                 status_skipped.append((name, str(exc)))
                 continue

--- a/openbadgeslib/ob3/signer.py
+++ b/openbadgeslib/ob3/signer.py
@@ -29,7 +29,7 @@ import jwt
 from .credential import OpenBadgeCredential, _SUPPORTED_ALGORITHMS
 from ..util import __version__
 from ..keys import key_to_pem
-from ..errors import ErrorSigningFile
+from ..errors import ErrorSigningFile, UnsupportedAlgorithm
 from .. import baking
 
 
@@ -47,7 +47,7 @@ class OB3Signer:
 
     def __init__(self, privkey_pem: Any, algorithm: str = 'RS256') -> None:
         if algorithm not in _SUPPORTED_ALGORITHMS:
-            raise ValueError(
+            raise UnsupportedAlgorithm(
                 f"Unsupported algorithm {algorithm!r}. "
                 f"Choose from: {sorted(_SUPPORTED_ALGORITHMS)}"
             )

--- a/openbadgeslib/ob3/status_list.py
+++ b/openbadgeslib/ob3/status_list.py
@@ -91,6 +91,11 @@ def build_status_list_credential(issuer_id: str, url: str, purpose: str,
     (ob3.status) then rejects a stale copy served past that instant, so a
     replayed old ``revocation.jwt`` cannot silently resurrect a revoked badge.
     The issuer must republish the list before it lapses (see the wiki).
+
+    Omitting *valid_until* publishes a list with NO anti-replay freshness — an
+    authentic older copy (with fewer revocations) passes the window unchecked.
+    openbadges-publish warns loudly when it does this; issuers of revocable
+    badges should set ``status_validity_days`` and republish on that cadence.
     """
     if purpose not in STATUS_PURPOSES:
         raise ValueError("statusPurpose must be one of %r, got %r"

--- a/openbadgeslib/openbadges_keygenerator.py
+++ b/openbadgeslib/openbadges_keygenerator.py
@@ -37,8 +37,9 @@ import sys
 from typing import Any
 
 from .logs import enable_debug_logging
-from .keys import KeyFactory, KeyType
-from .confparser import read_config_or_exit, resolve_badge_section
+from .keys import KeyFactory
+from .confparser import read_config_or_exit, resolve_badge_section, resolve_key_type
+from .errors import ConfigError
 from .util import __version__, emit_cli_json
 
 logger = logging.getLogger(__name__)
@@ -106,17 +107,12 @@ def _generate(args: argparse.Namespace) -> dict[str, Any]:
     private_key = conf[badge]['private_key']
     public_key = conf[badge]['public_key']
 
-    # Key type comes from the badge profile (default RSA).
-    key_type_name = conf[badge].get('key_type', 'RSA').strip().upper()
-    if key_type_name == 'ECC':
-        key_type = KeyType.ECC
-    elif key_type_name == 'RSA':
-        key_type = KeyType.RSA
-    elif key_type_name in ('ED25519', 'EDDSA'):
-        key_type = KeyType.ED25519
-    else:
-        sys.exit("Unknown key_type %r for badge '%s' (use RSA, ECC, or ED25519)"
-                 % (key_type_name, args.genkey))
+    # Key type comes from the badge profile (default RSA); resolve_key_type is
+    # the single home for the name->KeyType mapping and the default.
+    try:
+        key_type = resolve_key_type(conf[badge].get('key_type'))
+    except ConfigError as exc:
+        sys.exit("%s for badge '%s'" % (exc, args.genkey))
 
     for i in (private_key, public_key):
         if os.path.exists(i):

--- a/openbadgeslib/openbadges_publish.py
+++ b/openbadgeslib/openbadges_publish.py
@@ -371,6 +371,11 @@ def _publish_ob3(args: argparse.Namespace,
     for name in result.no_status_config:
         print('[i] [%s] has no status_lists configured; publishing no '
               'status list for it' % name)
+    for name in result.no_validity_bound:
+        print('[!] [%s] status list(s) published WITHOUT a validUntil bound — '
+              'no anti-replay freshness: a replayed older copy (with fewer '
+              'revocations) would pass. Set status_validity_days in the badge '
+              'section and republish before it lapses (see the wiki).' % name)
     for name, detail in result.status_skipped:
         print('[!] Skipping [%s] status lists — %s' % (name, detail))
 
@@ -427,6 +432,7 @@ def _publish_ob3(args: argparse.Namespace,
         'files_written': sorted(result.files_written),
         'status_operation': operation_result,
         'skipped': [n for n, _ in result.status_skipped],
+        'no_validity_bound': sorted(result.no_validity_bound),
         'live_check': live_check_json,
         '_exit': 2 if result.partial else 0,
     }

--- a/openbadgeslib/openbadges_signer.py
+++ b/openbadgeslib/openbadges_signer.py
@@ -218,11 +218,14 @@ def _write_badge_and_log(conf: configparser.ConfigParser, badge_file_out: str,
     reported but does not lose the already-written badge."""
     with open(badge_file_out, 'wb') as f:
         f.write(badge_bytes)
-    sign_log = os.path.join(conf['paths']['base_log'], conf['logs']['signer'])
     try:
+        # Resolve the log path inside the try: a missing [logs]/[paths] key is a
+        # KeyError, and the badge is already on disk — a log failure must be
+        # reported, not turned into a traceback that loses the written badge.
+        sign_log = os.path.join(conf['paths']['base_log'], conf['logs']['signer'])
         with open(sign_log, 'a') as file:
             file.write(msg + '\n')
-    except OSError as err:
+    except (OSError, KeyError) as err:
         print('[!] Could not write sign log: %s' % err)
     print('%s at: %s' % (msg, badge_file_out))
 

--- a/openbadgeslib/openbadges_signer.py
+++ b/openbadgeslib/openbadges_signer.py
@@ -43,11 +43,10 @@ from typing import Any, Optional
 from .keys import KeyType
 from .confparser import read_config_or_exit, resolve_badge_section
 from .logs import enable_debug_logging
-# Badge (the config-driven badge model) is shared across all OB versions here,
-# so it imports from the ob1 leaf module directly — reaching it through the
-# deprecated openbadgeslib.ob1 package surface would warn. The genuinely
-# OB1-only names (Signer, BadgeType) load lazily inside _sign_ob1.
-from .ob1.badge import Badge
+# Badge (the config-driven badge model) is shared across all OB versions, so it
+# lives in the neutral badge_model module. The genuinely OB1-only names (Signer,
+# BadgeType) load lazily inside _sign_ob1.
+from .badge_model import Badge
 from .mail import BadgeMail
 # Issuance orchestration lives in openbadgeslib.issue; this module is the CLI
 # front end (flag parsing, I/O and display) over it.

--- a/openbadgeslib/util.py
+++ b/openbadgeslib/util.py
@@ -25,6 +25,7 @@ __version__ = '3.14.0'
 
 import contextlib
 import hashlib
+import http.client
 import io
 import ipaddress
 import json
@@ -168,9 +169,10 @@ def _assert_public_host(url: str) -> None:
     is checked, and the check is re-applied to redirect targets in
     _HTTPSOnlyRedirectHandler (a public host can 30x to an internal address).
 
-    This is a pre-connection check; it does not on its own defeat DNS rebinding
-    (a name that resolves public here but private at connect time), which would
-    require pinning the socket to the validated address.
+    This is the early pre-connection check. DNS rebinding (a name that resolves
+    public here but private at connect time) is defeated separately by
+    :class:`_PinnedHTTPSConnection`, which re-resolves, re-validates and dials
+    the validated IP in one step for the actual HTTPS connection.
     """
     parts = urlparse(url)
     host = parts.hostname
@@ -218,10 +220,83 @@ class _HTTPSOnlyRedirectHandler(request.HTTPRedirectHandler):
         return super().redirect_request(req, fp, code, msg, headers, newurl)
 
 
+class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+    """An HTTPSConnection that resolves and SSRF-validates the host *at connect
+    time* and dials the validated IP, while still presenting the original
+    hostname for TLS SNI, certificate validation and the ``Host`` header.
+
+    ``_assert_public_host`` runs before the connection, but ``opener.open`` would
+    otherwise re-resolve on its own — a hostile DNS with TTL 0 can answer public
+    during the pre-check and internal (169.254.169.254, 127.0.0.1, RFC1918) on
+    the real connect (DNS rebinding). Resolving and connecting in the same breath
+    here closes that window: the IP that is validated is the exact IP dialed.
+    ``allow_private`` skips the classification for a private deployment.
+    """
+
+    def __init__(self, host: str, *args: Any,
+                 allow_private: bool = False, **kwargs: Any) -> None:
+        super().__init__(host, *args, **kwargs)
+        self._allow_private = allow_private
+
+    def connect(self) -> None:
+        port = self.port or 443
+        try:
+            addrs = _resolve_host(self.host, port)
+        except OSError as exc:
+            raise ValueError('Could not resolve host %r: %s'
+                             % (self.host, exc)) from exc
+        if not addrs:
+            raise ValueError('Could not resolve host %r' % self.host)
+        if not self._allow_private:
+            for ip_str in addrs:
+                if _ip_is_blocked(ip_str):
+                    raise ValueError(
+                        'Refusing to connect to %r: resolves to non-public '
+                        'address %s (possible SSRF / DNS rebinding).'
+                        % (self.host, ip_str))
+        # Dial the validated IP directly (no second resolution) by pointing the
+        # connection's socket factory at it, then delegate to the parent connect
+        # — which still uses self.host for TLS SNI, certificate verification and
+        # the Host header. urllib exposes _create_connection as an instance
+        # attribute precisely so it can be swapped like this.
+        pinned = addrs[0]
+        original = self._create_connection  # type: ignore[has-type]
+
+        def _dial_pinned(address: Any, *a: Any, **k: Any) -> Any:
+            return original((pinned, address[1]), *a, **k)
+
+        self._create_connection = _dial_pinned
+        try:
+            super().connect()
+        finally:
+            self._create_connection = original
+
+
+class _PinnedHTTPSHandler(request.HTTPSHandler):
+    """Route every HTTPS connection — the initial request and any redirect —
+    through :class:`_PinnedHTTPSConnection`, so the SSRF host check and the
+    socket connect share one DNS resolution (no rebinding window). TLS still
+    uses urllib's default verifying context (verify + hostname check)."""
+
+    def __init__(self, allow_private: bool = False) -> None:
+        super().__init__()
+        self._allow_private = allow_private
+
+    def https_open(self, req: Any) -> Any:
+        return self.do_open(
+            _PinnedHTTPSConnection, req, allow_private=self._allow_private)
+
+
 #: Verify keys, issuer documents, and revocation lists are all small JSON/PEM
 #: payloads; cap reads well above any legitimate size to bound memory use
 #: against an attacker-influenced URL serving an oversized/streamed response.
 MAX_DOWNLOAD_SIZE = 5 * 1024 * 1024  # 5 MiB
+
+#: Global wall-clock budget for a single download. ``timeout=30`` on the socket
+#: is per-operation, so a server that drips one byte per 29 s would hold the
+#: connection open far longer than any legitimate small fetch needs; the size
+#: cap bounds bytes but not time. This bounds the total read wall-clock.
+MAX_DOWNLOAD_SECONDS = 60
 
 
 def download_file(url: str, allow_insecure: bool = False,
@@ -255,12 +330,23 @@ def download_file(url: str, allow_insecure: bool = False,
     if not allow_private:
         _assert_public_host(url)
 
+    # _PinnedHTTPSHandler pins the connection to the validated IP (defeats DNS
+    # rebinding); the redirect handler re-applies the scheme/host checks to any
+    # 30x target (which then also connects through the pinned handler).
     opener = request.build_opener(
+        _PinnedHTTPSHandler(allow_private),
         _HTTPSOnlyRedirectHandler(allow_insecure, allow_private))
+    deadline = time.monotonic() + MAX_DOWNLOAD_SECONDS
     with opener.open(url, timeout=30) as response:
         chunks = []
         total = 0
         while True:
+            # A per-socket timeout does not bound total time: a slow-drip server
+            # can keep resetting it. Enforce a wall-clock budget too.
+            if time.monotonic() > deadline:
+                raise ValueError(
+                    'Refusing to download %s: exceeded the %d-second time budget '
+                    '(slow-drip response)' % (url, MAX_DOWNLOAD_SECONDS))
             chunk = response.read(65536)
             if not chunk:
                 break

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -540,7 +540,7 @@ def test_publish_restores_umask_when_a_badge_mkdir_fails(tmp_path):
 # ── Badge.urls_has_problems ─────────────────────────────────────────────────────
 
 def test_urls_has_problems_all_ok(svg_rsa_badge):
-    with patch('openbadgeslib.ob1.badge.download_file', return_value=b'data'):
+    with patch('openbadgeslib.badge_model.download_file', return_value=b'data'):
         assert svg_rsa_badge.urls_has_problems() is False
 
 
@@ -555,7 +555,7 @@ def test_urls_has_problems_detects_later_failure(svg_rsa_badge):
             raise ValueError('unreachable')
         return b'data'
 
-    with patch('openbadgeslib.ob1.badge.download_file', side_effect=fake_download):
+    with patch('openbadgeslib.badge_model.download_file', side_effect=fake_download):
         assert svg_rsa_badge.urls_has_problems() is True
 
 
@@ -727,7 +727,7 @@ def test_signer_ob2_writes_file_and_log(tmp_path, capsys):
     cfg = _write_ob2_sign_config(tmp_path)
     argv = ['openbadges-signer', '-c', str(cfg), '-b', '1',
             '-r', 'recipient@example.com', '-o', str(tmp_path), '-V', '1', '-E']
-    with patch('openbadgeslib.ob1.badge.download_file', return_value=b'data'), \
+    with patch('openbadgeslib.badge_model.download_file', return_value=b'data'), \
             patch.object(sys, 'argv', argv):
         openbadges_signer.main()
     out = capsys.readouterr().out
@@ -743,7 +743,7 @@ def test_signer_ob2_mail_badge_sends(tmp_path):
     argv = ['openbadges-signer', '-c', str(cfg), '-b', '1',
             '-r', 'recipient@example.com', '-o', str(tmp_path), '-V', '1', '-E', '-M']
     smtp = MagicMock()
-    with patch('openbadgeslib.ob1.badge.download_file', return_value=b'data'), \
+    with patch('openbadgeslib.badge_model.download_file', return_value=b'data'), \
             patch('openbadgeslib.mail.SMTP', return_value=smtp), \
             patch.object(sys, 'argv', argv):
         openbadges_signer.main()
@@ -761,7 +761,7 @@ def test_signer_ob2_mail_badge_auth_without_ssl_reports_clean_error(tmp_path, ca
         'mail_from = no-reply@example.com\nusername = user\npassword = pass\n'))
     argv = ['openbadges-signer', '-c', str(cfg), '-b', '1',
             '-r', 'recipient@example.com', '-o', str(tmp_path), '-V', '1', '-E', '-M']
-    with patch('openbadgeslib.ob1.badge.download_file', return_value=b'data'), \
+    with patch('openbadgeslib.badge_model.download_file', return_value=b'data'), \
             patch.object(sys, 'argv', argv):
         openbadges_signer.main()   # must not raise
     out = capsys.readouterr().out
@@ -781,7 +781,7 @@ def test_signer_ob2_mail_badge_missing_template_reports_clean_error(tmp_path, ca
         'mail = %s\n' % (tmp_path / 'nonexistent-mail.txt')))
     argv = ['openbadges-signer', '-c', str(cfg), '-b', '1',
             '-r', 'recipient@example.com', '-o', str(tmp_path), '-V', '1', '-E', '-M']
-    with patch('openbadgeslib.ob1.badge.download_file', return_value=b'data'), \
+    with patch('openbadgeslib.badge_model.download_file', return_value=b'data'), \
             patch.object(sys, 'argv', argv):
         openbadges_signer.main()   # must not raise
     out = capsys.readouterr().out

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -46,6 +46,11 @@ def test_init_creates_directories_with_restrictive_permissions(tmp_path):
     # (not just keys/) ends up owner-only (0700), not world/group readable.
     import os
     import stat
+    import pytest
+    if os.name == 'nt':
+        # POSIX file-mode semantics: on Windows umask/chmod do not map to 0700
+        # (the dir reports 0777), so this owner-only control is POSIX-only.
+        pytest.skip('POSIX file-mode semantics; Windows uses ACLs')
     from openbadgeslib import openbadges_init
     target = tmp_path / 'config'
     with patch.object(sys, 'argv', ['openbadges-init', str(target)]):

--- a/tests/test_confparser.py
+++ b/tests/test_confparser.py
@@ -79,7 +79,10 @@ class TestReadConfBaseValidation:
         p.write_text('[paths]\nbase = data\nbase_key = ${base}/keys\n')
         conf = ConfParser(str(p)).read_conf()
         assert conf['paths']['base'] == os.path.join(str(d), 'data')
-        assert conf['paths']['base_key'] == os.path.join(str(d), 'data', 'keys')
+        # base_key is ${base} + the INI's literal '/keys'; the separator after
+        # base stays '/' on every platform (os.path.join would use '\' on
+        # Windows and spuriously mismatch), so compare against base + '/keys'.
+        assert conf['paths']['base_key'] == conf['paths']['base'] + '/keys'
 
     def test_nonexistent_file_returns_none(self, tmp_path):
         assert ConfParser(str(tmp_path / 'missing.ini')).read_conf() is None

--- a/tests/test_confparser.py
+++ b/tests/test_confparser.py
@@ -197,3 +197,115 @@ class TestOb3StatusConfigSizeBits:
         from openbadgeslib.confparser import ob3_status_config
         with pytest.raises(ValueError, match='positive multiple of 8'):
             ob3_status_config(self._conf(0), 'badge_1')
+
+
+class TestLoadConfig:
+    """load_config is the library entry point (raises ConfigError);
+    read_config_or_exit is the thin CLI wrapper over it (prints + exits)."""
+
+    def test_returns_configparser_for_valid_file(self, tmp_path):
+        from openbadgeslib.confparser import load_config
+        conf = load_config(_write(tmp_path, '[paths]\nbase = .\n'))
+        assert conf['paths']['base'] == str(tmp_path)
+
+    def test_missing_file_raises_config_error(self, tmp_path):
+        from openbadgeslib.confparser import load_config
+        from openbadgeslib.errors import ConfigError
+        with pytest.raises(ConfigError, match='does not exist or is empty'):
+            load_config(str(tmp_path / 'missing.ini'))
+
+    def test_malformed_raises_config_error(self, tmp_path):
+        from openbadgeslib.confparser import load_config
+        from openbadgeslib.errors import ConfigError
+        path = _write(tmp_path, '[logs]\ngeneral = general.log\n')  # no [paths]
+        with pytest.raises(ConfigError):
+            load_config(path)
+
+    def test_config_error_is_still_a_value_error(self, tmp_path):
+        # Backward compat: an integrator catching ValueError keeps working.
+        from openbadgeslib.confparser import load_config
+        with pytest.raises(ValueError):
+            load_config(str(tmp_path / 'missing.ini'))
+
+
+class TestResolveKeyType:
+    def test_defaults_to_rsa(self):
+        from openbadgeslib.confparser import resolve_key_type
+        from openbadgeslib.keys import KeyType
+        assert resolve_key_type(None) is KeyType.RSA
+        assert resolve_key_type('') is KeyType.RSA
+
+    def test_maps_names_case_insensitively(self):
+        from openbadgeslib.confparser import resolve_key_type
+        from openbadgeslib.keys import KeyType
+        assert resolve_key_type('ecc') is KeyType.ECC
+        assert resolve_key_type(' ED25519 ') is KeyType.ED25519
+        assert resolve_key_type('eddsa') is KeyType.ED25519   # alias
+
+    def test_unknown_name_raises_config_error(self):
+        from openbadgeslib.confparser import resolve_key_type
+        from openbadgeslib.errors import ConfigError
+        with pytest.raises(ConfigError, match='Unknown key_type'):
+            resolve_key_type('dsa')
+
+
+class TestIssuerConfig:
+    def _conf(self, **issuer):
+        from configparser import ConfigParser
+        conf = ConfigParser()
+        if issuer:
+            conf['issuer'] = {k: v for k, v in issuer.items() if v is not None}
+        return conf
+
+    def test_resolves_fields_and_id(self):
+        from openbadgeslib.confparser import issuer_config
+        cfg = issuer_config(self._conf(
+            name='Acme', url='https://acme.example',
+            publish_url='https://acme.example/', email='a@acme.example'))
+        assert cfg.name == 'Acme'
+        assert cfg.id == 'https://acme.example/'   # publish_url is the OB3 id
+        assert cfg.url == 'https://acme.example'
+        assert cfg.email == 'a@acme.example'
+
+    def test_missing_section_raises_config_error(self):
+        from openbadgeslib.confparser import issuer_config
+        from openbadgeslib.errors import ConfigError
+        with pytest.raises(ConfigError, match=r'\[issuer\] section'):
+            issuer_config(self._conf())
+
+    def test_missing_name_raises_config_error(self):
+        from openbadgeslib.confparser import issuer_config
+        from openbadgeslib.errors import ConfigError
+        with pytest.raises(ConfigError, match="required 'name'"):
+            issuer_config(self._conf(url='https://acme.example'))
+
+
+class TestBadgeSectionConfig:
+    def _conf(self, **badge):
+        from configparser import ConfigParser
+        conf = ConfigParser()
+        conf['badge_1'] = {k: v for k, v in badge.items() if v is not None}
+        return conf
+
+    def test_criteria_narrative_used_when_present(self):
+        from openbadgeslib.confparser import badge_section_config
+        bsc = badge_section_config(
+            self._conf(criteria_narrative='Do the thing',
+                       criteria='https://x/c.html'), 'badge_1')
+        assert bsc.criteria_narrative == 'Do the thing'
+
+    def test_falls_back_to_ob1_criteria(self):
+        from openbadgeslib.confparser import badge_section_config
+        bsc = badge_section_config(
+            self._conf(criteria='https://x/c.html'), 'badge_1')
+        assert bsc.criteria_narrative == 'https://x/c.html'
+
+    def test_empty_when_neither_present(self):
+        from openbadgeslib.confparser import badge_section_config
+        assert badge_section_config(self._conf(), 'badge_1').criteria_narrative == ''
+
+    def test_hosted_assertions_base(self):
+        from openbadgeslib.confparser import badge_section_config
+        bsc = badge_section_config(
+            self._conf(hosted_assertions_base='https://x/a/'), 'badge_1')
+        assert bsc.hosted_assertions_base == 'https://x/a/'

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,92 @@
+"""Exception-hierarchy contract (#224).
+
+`except LibOpenBadgesException` must catch every error the library raises, and
+the config/algorithm errors must stay `ValueError` for backward compatibility.
+"""
+import configparser
+
+import pytest
+
+from openbadgeslib import errors
+from openbadgeslib.errors import (
+    LibOpenBadgesException, ConfigError, IssuanceError,
+    DecompressionLimitExceeded, UnsupportedAlgorithm,
+    KeyGenException, SignerException, VerifierException,
+    KeyGenExceptions, SignerExceptions, VerifierExceptions,
+)
+
+
+class TestHierarchyIsUnderTheRoot:
+    """Every library exception derives from LibOpenBadgesException so a single
+    ``except`` traps them all — the OB2VerificationError docstring's promise."""
+
+    @pytest.mark.parametrize('exc', [
+        ConfigError, IssuanceError, DecompressionLimitExceeded,
+        UnsupportedAlgorithm, KeyGenExceptions, SignerExceptions,
+        VerifierExceptions, errors.BadgeImgFormatUnsupported,
+        errors.StatusError, errors.ErrorSigningFile, errors.UnknownKeyType,
+    ])
+    def test_is_lib_exception(self, exc):
+        assert issubclass(exc, LibOpenBadgesException)
+
+    def test_reanchored_errors_are_reachable_from_old_modules(self):
+        # The moved classes keep their historical import paths.
+        from openbadgeslib.issue import IssuanceError as IssueSideError
+        from openbadgeslib.baking import (
+            DecompressionLimitExceeded as BakingSideError)
+        assert IssueSideError is IssuanceError
+        assert BakingSideError is DecompressionLimitExceeded
+
+    def test_ob2_ob3_verification_errors_are_lib_exceptions(self):
+        from openbadgeslib.ob2.verifier import OB2VerificationError
+        from openbadgeslib.ob3.verifier import OB3VerificationError
+        assert issubclass(OB2VerificationError, LibOpenBadgesException)
+        assert issubclass(OB3VerificationError, LibOpenBadgesException)
+
+
+class TestValueErrorCompatibility:
+    """ConfigError and UnsupportedAlgorithm stay ValueError so historical
+    ``except ValueError`` callers (and the tests) keep working."""
+
+    def test_config_error_is_value_error(self):
+        assert issubclass(ConfigError, ValueError)
+
+    def test_unsupported_algorithm_is_value_error(self):
+        assert issubclass(UnsupportedAlgorithm, ValueError)
+
+    def test_config_error_caught_both_ways(self):
+        with pytest.raises(ValueError):
+            raise ConfigError('boom')
+        with pytest.raises(LibOpenBadgesException):
+            raise ConfigError('boom')
+
+
+class TestSingularAliases:
+    """Singular aliases for the plural base families."""
+
+    def test_aliases(self):
+        assert KeyGenException is KeyGenExceptions
+        assert SignerException is SignerExceptions
+        assert VerifierException is VerifierExceptions
+
+
+class TestWriteBadgeAndLogSurvivesMissingLogsSection:
+    """`_write_badge_and_log` reads the log path inside its try, so a missing
+    [logs]/[paths] key is reported — not a traceback that loses the already
+    written badge (#224)."""
+
+    def _conf_without_logs(self):
+        conf = configparser.ConfigParser()
+        conf.read_dict({'paths': {'base': '/tmp'}})  # no base_log, no [logs]
+        return conf
+
+    def test_badge_written_and_no_exception(self, tmp_path, capsys):
+        from openbadgeslib.openbadges_signer import _write_badge_and_log
+        out = tmp_path / 'badge.svg'
+        # Must not raise even though conf has neither base_log nor [logs].
+        _write_badge_and_log(self._conf_without_logs(), str(out),
+                             b'<svg/>', 'X SIGNED for y')
+        assert out.read_bytes() == b'<svg/>'  # badge is on disk
+        printed = capsys.readouterr().out
+        assert 'Could not write sign log' in printed
+        assert 'X SIGNED for y at:' in printed

--- a/tests/test_issue.py
+++ b/tests/test_issue.py
@@ -129,6 +129,25 @@ class TestIssueOb3:
         with pytest.raises(IssuanceError):
             issue_from_conf(conf, 'badge_1', 'r@example.com', '3')
 
+    def test_ob3_issues_without_ob1_verify_key_and_criteria(self, tmp_path):
+        # #223: verify_key and criteria are OpenBadges 1.0 fields; an OB3 config
+        # that omits them must issue cleanly, not blow up with a raw
+        # KeyError('verify_key') out of Badge.create_from_conf.
+        conf = _write_conf(tmp_path)
+        conf.remove_option('badge_1', 'verify_key')
+        conf.remove_option('badge_1', 'criteria')
+        result = issue_from_conf(conf, 'badge_1', 'r@example.com', '3')
+        assert result.badge_bytes
+        assert result.ob_version == '3'
+
+    def test_missing_required_badge_key_raises_issuance_error(self, tmp_path):
+        # #223: a genuinely missing *required* key (name) surfaces as
+        # IssuanceError, not a raw KeyError, honouring the documented contract.
+        conf = _write_conf(tmp_path)
+        conf.remove_option('badge_1', 'name')
+        with pytest.raises(IssuanceError, match='config key'):
+            issue_from_conf(conf, 'badge_1', 'r@example.com', '3')
+
 
 class TestIssueOb2:
     def test_signed_returns_bytes_and_assertion(self, tmp_path):

--- a/tests/test_jsonmodel.py
+++ b/tests/test_jsonmodel.py
@@ -1,0 +1,69 @@
+"""Shared OB2/OB3 JSON helpers (#225).
+
+The four helpers `_iso` / `_parse_iso` / `_as_dict` / `_require` used to be
+duplicated in ob2.models and ob3.credential and had drifted — the OB2 `_iso`
+serialised a naive datetime as *local* time. They are now a single
+implementation in openbadgeslib._jsonmodel with the OB3 (naive => UTC) rule.
+"""
+from datetime import datetime, timezone
+
+import pytest
+
+from openbadgeslib import _jsonmodel as jm
+from openbadgeslib.ob2 import models as ob2_models
+from openbadgeslib.ob3 import credential as ob3_credential
+
+
+class TestHelpersAreDeduplicated:
+    def test_ob2_and_ob3_share_one_implementation(self):
+        assert ob2_models._iso is jm._iso is ob3_credential._iso
+        assert ob2_models._parse_iso is jm._parse_iso is ob3_credential._parse_iso
+        assert ob2_models._as_dict is jm._as_dict is ob3_credential._as_dict
+        assert ob2_models._require is jm._require is ob3_credential._require
+
+
+class TestIsoNaiveIsUTCNotLocal:
+    """The bug this dedup fixes: a naive datetime must serialise as UTC, so OB2
+    and OB3 emit the same instant regardless of the host's timezone."""
+
+    def test_naive_datetime_treated_as_utc(self):
+        assert jm._iso(datetime(2026, 1, 1, 12, 0, 0)) == '2026-01-01T12:00:00Z'
+
+    def test_aware_datetime_converted_to_utc(self):
+        from datetime import timedelta
+        plus2 = timezone(timedelta(hours=2))
+        assert jm._iso(datetime(2026, 1, 1, 12, 0, 0, tzinfo=plus2)) \
+            == '2026-01-01T10:00:00Z'
+
+
+class TestParseIso:
+    def test_default_where_matches_ob3_message(self):
+        # ob3 called _parse_iso(s) with no `where`; the default keeps its message.
+        with pytest.raises(ValueError, match='date is missing a UTC offset'):
+            jm._parse_iso('2026-01-01T00:00:00')
+
+    def test_named_where_for_ob2_callers(self):
+        with pytest.raises(ValueError, match='assertion.issuedOn'):
+            jm._parse_iso('not-a-date', 'assertion.issuedOn')
+
+    def test_rejects_non_string(self):
+        with pytest.raises(ValueError, match='must be an ISO 8601 string'):
+            jm._parse_iso(1767225600, 'x')
+
+    def test_roundtrip(self):
+        dt = jm._parse_iso('2026-01-01T00:00:00Z')
+        assert dt == datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+class TestAsDictAndRequire:
+    def test_as_dict_rejects_non_dict(self):
+        with pytest.raises(ValueError, match='must be a JSON object'):
+            jm._as_dict([], 'x')
+
+    def test_require_rejects_missing(self):
+        with pytest.raises(ValueError, match='missing required field'):
+            jm._require({}, 'id', 'obj')
+
+    def test_require_rejects_non_string(self):
+        with pytest.raises(ValueError, match='must be a string'):
+            jm._require({'id': 5}, 'id', 'obj')

--- a/tests/test_ob3_eudi_sd_jwt.py
+++ b/tests/test_ob3_eudi_sd_jwt.py
@@ -141,3 +141,66 @@ class TestExtraAbsent:
             monkeypatch.setitem(sys.modules, name, None)
         with pytest.raises(EudiError, match=r"openbadgeslib\[eudi\]"):
             issue_badge_sd_jwt(ob3_credential, privkey_pem=ed25519_priv_pem)
+
+
+# ── #226: irrevocability + identifier carriage (pure-Python, no [eudi]) ───────
+
+class TestSdJwtStatusAndIdentifier:
+    """SD-JWT VC badges are irrevocable, so a credentialStatus is rejected at
+    issuance (not silently dropped), and the recipient's hashed identifier is
+    carried under credentialSubject. These paths need no openvc.
+
+    ``ob3_credential`` is a session fixture — never mutate it; derive a variant
+    with ``dataclasses.replace`` so other tests keep the pristine credential.
+    """
+
+    _STATUS = [{
+        "id": "https://issuer.example/status/badge_1#5",
+        "type": "BitstringStatusListEntry",
+        "statusPurpose": "revocation",
+        "statusListIndex": "5",
+        "statusListCredential": "https://issuer.example/status/badge_1.jwt",
+    }]
+
+    def _identifier(self, ihash="sha256$abc"):
+        from openbadgeslib.ob3.credential import IdentityObject
+        return IdentityObject(identity_hash=ihash, identity_type="emailAddress",
+                              hashed=True)
+
+    def test_issue_rejects_credential_with_status(self, ob3_credential,
+                                                  ed25519_priv_pem):
+        from dataclasses import replace
+        cred = replace(ob3_credential, credential_status=list(self._STATUS))
+        with pytest.raises(EudiError, match="irrevocable"):
+            issue_badge_sd_jwt(cred, privkey_pem=ed25519_priv_pem)
+
+    def test_rejection_precedes_the_openvc_requirement(self, ob3_credential):
+        # The clear error fires even with a bogus key (before _require_openvc),
+        # so an issuer without the [eudi] extra still gets it, not ImportError.
+        from dataclasses import replace
+        cred = replace(ob3_credential, credential_status=list(self._STATUS))
+        with pytest.raises(EudiError, match="credentialStatus"):
+            issue_badge_sd_jwt(cred, privkey_pem=b"not-a-key")
+
+    def test_identifier_carried_alongside_id(self, ob3_credential):
+        from dataclasses import replace
+        cred = replace(ob3_credential, identifiers=[self._identifier()])
+        subject = badge_to_sd_jwt_claims(cred)["credentialSubject"]
+        assert subject["id"] == cred.recipient_id
+        assert subject["identifier"] == [{
+            "type": "IdentityObject", "hashed": True,
+            "identityHash": "sha256$abc", "identityType": "emailAddress"}]
+
+    def test_identifier_only_subject_has_no_id(self, ob3_credential):
+        from dataclasses import replace
+        cred = replace(ob3_credential, recipient_id=None,
+                       identifiers=[self._identifier("sha256$xyz")])
+        subject = badge_to_sd_jwt_claims(cred)["credentialSubject"]
+        assert "id" not in subject
+        assert subject["identifier"][0]["identityHash"] == "sha256$xyz"
+
+    def test_no_status_credential_still_issues_claims(self, ob3_credential):
+        # The common case (no status) is unaffected: claims build fine.
+        claims = badge_to_sd_jwt_claims(ob3_credential)
+        assert "credentialStatus" not in claims
+        assert claims["credentialSubject"]["id"] == ob3_credential.recipient_id

--- a/tests/test_ob3_ldp_ecdsa_sd.py
+++ b/tests/test_ob3_ldp_ecdsa_sd.py
@@ -79,10 +79,12 @@ def _issue_and_derive(ob3_credential, *, selective):
 def _require_ldp_sd() -> None:
     """Ensure the [ldp-sd] delegate stack (openvc-core + pyld) is importable.
 
-    Missing it SKIPs locally, but FAILs under CI (``CI=true``): CI installs the
-    extra on purpose, so an import that stops resolving there — e.g. an
-    openvc-core packaging change — must turn the whole ecdsa-sd-2023 suite red
-    instead of letting it pass by skipping in silence (#221).
+    Missing it SKIPs, except where the extra is installed on purpose — the main
+    CI test job sets ``OPENBADGES_REQUIRE_LDP_SD=1`` — where it FAILs instead, so
+    an import that stops resolving there (e.g. an openvc-core packaging change)
+    turns the whole ecdsa-sd-2023 suite red rather than passing by skipping in
+    silence (#221). A core-only CI leg that deliberately omits [ldp-sd] (e.g. the
+    windows-latest leg) does not set the flag and so skips cleanly (#230).
     """
     for mod in ('openvc', 'pyld'):
         try:
@@ -90,7 +92,7 @@ def _require_ldp_sd() -> None:
         except ImportError as exc:
             reason = ('the [ldp-sd] extra is required for the ecdsa-sd-2023 '
                       'tests but %r is not importable: %s' % (mod, exc))
-            if os.environ.get('CI') == 'true':
+            if os.environ.get('OPENBADGES_REQUIRE_LDP_SD') == '1':
                 pytest.fail(reason, pytrace=False)
             pytest.skip(reason)
 
@@ -142,6 +144,10 @@ class TestEcdsaSdVerify:
     def test_selective_omission(self, ob3_credential):
         # Withhold credentialSchema entirely: still verifies, and the field is
         # absent from the presentation the verifier sees.
+        # Unlike the other tests this uses ob3_credential (not the sd_credential
+        # fixture), so it must run the [ldp-sd] guard itself — otherwise the
+        # direct openvc import in _issue_and_derive would fail instead of skip.
+        _require_ldp_sd()
         derived, pub_pem, _ = _issue_and_derive(ob3_credential, selective=[])
         assert 'credentialSchema' not in derived
         OB3LdpVerifier(pubkey_pem=pub_pem).verify(derived)

--- a/tests/test_ob3_publish_cli.py
+++ b/tests/test_ob3_publish_cli.py
@@ -15,7 +15,7 @@ RECIPIENT = 'recipient@example.com'
 
 
 def _write_config(tmp_path, key='rsa', status_lists=None, did=None,
-                  status_base=None, sd_jwt_vct=None):
+                  status_base=None, sd_jwt_vct=None, status_validity_days=None):
     (tmp_path / 'log').mkdir(exist_ok=True)
     lines = [
         "[paths]",
@@ -56,6 +56,8 @@ def _write_config(tmp_path, key='rsa', status_lists=None, did=None,
         lines.append("status_lists = %s" % status_lists)
     if status_base is not None:
         lines.append("status_base = %s" % status_base)
+    if status_validity_days is not None:
+        lines.append("status_validity_days = %s" % status_validity_days)
     cfg = tmp_path / 'cfg.ini'
     cfg.write_text("\n".join(lines) + "\n")
     return cfg
@@ -297,6 +299,21 @@ class TestPublishGeneration:
         pub = _publish(tmp_path, cfg)
         _publish(tmp_path, cfg)   # unlike -V 1/2 this must not exit
         assert (pub / 'badge_1' / 'revocation.jwt').is_file()
+
+    def test_cli_warns_when_no_validity_bound(self, tmp_path, capsys):
+        # #227: publishing a revocable badge with no status_validity_days warns
+        # loudly (no anti-replay freshness on the list).
+        cfg = _write_config(tmp_path, status_lists='revocation')
+        _sign(tmp_path, cfg)
+        _publish(tmp_path, cfg)
+        assert 'WITHOUT a validUntil bound' in capsys.readouterr().out
+
+    def test_cli_no_warning_when_validity_days_set(self, tmp_path, capsys):
+        cfg = _write_config(tmp_path, status_lists='revocation',
+                            status_validity_days=7)
+        _sign(tmp_path, cfg)
+        _publish(tmp_path, cfg)
+        assert 'WITHOUT a validUntil bound' not in capsys.readouterr().out
 
     @pytest.mark.parametrize('key,alg', [('rsa', 'RS256'), ('ecc', 'ES256')])
     def test_lists_are_signed_with_the_badge_key(self, tmp_path, key, alg):
@@ -847,6 +864,28 @@ class TestPublishFacade:
         with pytest.raises(CredentialNotFound):
             publish_ob3(self._conf(cfg), str(tmp_path / 'pub'),
                         revoke='urn:uuid:does-not-exist')
+
+    def test_no_validity_bound_flagged_when_days_unset(self, tmp_path):
+        # #227: a revocable badge published without status_validity_days has no
+        # validUntil, hence no anti-replay freshness — the facade flags it.
+        from openbadgeslib.ob3.publish import publish_ob3
+        cfg = _write_config(tmp_path, status_lists='revocation')
+        res = publish_ob3(self._conf(cfg), str(tmp_path / 'pub'))
+        assert res.no_validity_bound == ['badge_1']
+
+    def test_validity_days_stamps_validuntil_and_clears_flag(self, tmp_path):
+        # #227: with status_validity_days set, the published list carries a
+        # validUntil and the badge is not flagged.
+        import jwt as pyjwt
+        from openbadgeslib.ob3.publish import publish_ob3
+        cfg = _write_config(tmp_path, status_lists='revocation',
+                            status_validity_days=7)
+        out = tmp_path / 'pub'
+        res = publish_ob3(self._conf(cfg), str(out))
+        assert res.no_validity_bound == []
+        token = (out / 'badge_1' / 'revocation.jwt').read_text()
+        payload = pyjwt.decode(token, options={'verify_signature': False})
+        assert 'validUntil' in payload
 
     def test_reason_without_revoke_raises(self, tmp_path):
         from openbadgeslib.ob3.publish import PublishError, publish_ob3

--- a/tests/test_ob3_status_registry.py
+++ b/tests/test_ob3_status_registry.py
@@ -87,6 +87,33 @@ class TestLocked:
         assert len({e.index for e in registry.entries.values()}) == n
 
 
+class TestNoFcntlFallback:
+    """Where fcntl is unavailable (Windows, the "OS Independent" classifier's
+    other side) the advisory lock degrades to a no-op — load/allocate/save must
+    still work. Monkeypatch fcntl=None so the fallback is exercised on POSIX too,
+    the path only a windows-latest CI leg would otherwise reach (#230)."""
+
+    def test_exclusive_file_lock_is_a_noop_without_fcntl(self, tmp_path, monkeypatch):
+        from openbadgeslib.ob3 import status_registry
+        monkeypatch.setattr(status_registry, 'fcntl', None)
+        lock_path = str(tmp_path / 'badge_1.json.lock')
+        # No flock is called, but the block still runs and the fd is created and
+        # closed cleanly (no leak, no raise).
+        with status_registry._exclusive_file_lock(lock_path):
+            pass
+        assert os.path.exists(lock_path)
+
+    def test_locked_registry_roundtrip_without_fcntl(self, tmp_path, monkeypatch):
+        from openbadgeslib.ob3 import status_registry
+        monkeypatch.setattr(status_registry, 'fcntl', None)
+        path = str(tmp_path / 'badge_1.json')
+        with status_registry.StatusRegistry.locked(path, 131072) as registry:
+            registry.allocate(JTI, 'mailto:a@example.org', NOW)
+            registry.save()
+        assert os.path.exists(path + '.lock')
+        assert JTI in StatusRegistry.load(path, 131072).entries
+
+
 # ── allocation ───────────────────────────────────────────────────────────────
 
 class TestAllocate:

--- a/tests/test_ob3_status_registry.py
+++ b/tests/test_ob3_status_registry.py
@@ -191,6 +191,9 @@ class TestPersistence:
         assert path.exists()
         assert [p.name for p in path.parent.iterdir()] == ['badge_1.json']
 
+    @pytest.mark.skipif(
+        os.name == 'nt',
+        reason='POSIX file-mode semantics; Windows uses ACLs, not 0o600')
     def test_save_is_private(self, tmp_path):
         reg = _registry(tmp_path)
         reg.save()

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,78 @@
+"""The stable public surface (#232).
+
+The top-level package declares an explicit __all__ (the "public contract"),
+re-exports KeyEd25519 and the eudi track, and types the SignResult boundary
+fields instead of leaving them Any. These tests lock that contract.
+"""
+import warnings
+
+import pytest
+
+
+class TestTopLevelAll:
+    def test_all_is_declared(self):
+        import openbadgeslib
+        assert isinstance(openbadgeslib.__all__, list)
+
+    @pytest.mark.parametrize('name', [
+        '__version__', 'ob2', 'ob3', 'errors',
+        'OB2Signer', 'OB2Verifier', 'OB2VerificationError',
+        'OB3Signer', 'OB3Verifier', 'OB3VerificationError',
+        'OpenBadgeCredential', 'Achievement', 'Issuer',
+        'KeyFactory', 'KeyRSA', 'KeyECC', 'KeyEd25519',
+        'issue_from_conf', 'verify_badge', 'IssuanceError', 'SignResult',
+    ])
+    def test_contract_name_present_and_resolvable(self, name):
+        import openbadgeslib
+        assert name in openbadgeslib.__all__
+        assert getattr(openbadgeslib, name) is not None
+
+    def test_key_ed25519_is_the_recommended_ob3_key(self):
+        from openbadgeslib import KeyEd25519
+        from openbadgeslib.keys import KeyEd25519 as Direct
+        assert KeyEd25519 is Direct
+
+    def test_import_star_binds_the_contract(self):
+        ns = {}
+        exec('from openbadgeslib import *', ns)
+        for name in ('OB3Signer', 'KeyEd25519', 'verify_badge',
+                     'issue_from_conf', 'ob3'):
+            assert name in ns
+
+
+class TestBareImportIsClean:
+    def test_bare_import_does_not_warn(self):
+        # A plain `import openbadgeslib` must not drag in (or warn about) the
+        # legacy OB1 shims; the modern facades resolve lazily and warning-free.
+        import importlib
+        import openbadgeslib
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', DeprecationWarning)
+            importlib.reload(openbadgeslib)
+            assert openbadgeslib.issue_from_conf is not None
+            assert openbadgeslib.verify_badge is not None
+
+    def test_legacy_ob1_names_still_work_but_warn(self):
+        import openbadgeslib
+        with pytest.warns(DeprecationWarning):
+            _ = openbadgeslib.Signer          # legacy OB1 compat shim
+
+
+class TestEudiReExport:
+    def test_eudi_reachable_from_ob3(self):
+        from openbadgeslib import ob3
+        assert 'eudi' in ob3.__all__
+        assert hasattr(ob3.eudi, 'issue_badge_sd_jwt')
+
+
+class TestSignResultBoundaryTypesAreNotAny:
+    def test_credential_and_assertion_are_typed(self):
+        # The boundary fields carry real forward refs (resolved under
+        # TYPE_CHECKING, so they don't exist at runtime — get_type_hints would
+        # NameError, which is the whole point: zero runtime cost). Assert on the
+        # stored annotation instead.
+        from openbadgeslib.issue import SignResult
+        cred = str(SignResult.__annotations__['credential'])
+        assert 'OpenBadgeCredential' in cred and 'Any' not in cred
+        assn = str(SignResult.__annotations__['assertion'])
+        assert 'Assertion' in assn and 'Any' not in assn

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -255,13 +255,15 @@ class TestHTTPSOnlyRedirectHandler:
             self._get_request(), None, 302, 'Found', {}, 'https://example.com/key.pem')
         assert req is not None
 
-    def test_download_file_uses_https_only_redirect_handler(self):
-        from openbadgeslib.util import _HTTPSOnlyRedirectHandler
+    def test_download_file_uses_pinned_and_redirect_handlers(self):
+        from openbadgeslib.util import (_HTTPSOnlyRedirectHandler,
+                                        _PinnedHTTPSHandler)
         mock_opener = _mock_opener()
         with patch('openbadgeslib.util.request.build_opener', return_value=mock_opener) as m:
             download_file('https://example.com/file.pem')
-        (handler,), _ = m.call_args
-        assert isinstance(handler, _HTTPSOnlyRedirectHandler)
+        handlers, _ = m.call_args
+        assert any(isinstance(h, _PinnedHTTPSHandler) for h in handlers)
+        assert any(isinstance(h, _HTTPSOnlyRedirectHandler) for h in handlers)
 
 
 class TestSSRFProtection:
@@ -323,6 +325,69 @@ class TestSSRFProtection:
             with pytest.raises(ValueError):
                 _HTTPSOnlyRedirectHandler(allow_insecure=False).redirect_request(
                     req, None, 302, 'Found', {}, 'https://evil.example/x')
+
+
+class TestDNSRebindingPinning:
+    """_PinnedHTTPSConnection resolves + validates at connect time and dials the
+    validated IP, so a name that answers public at the pre-check but private at
+    connect (DNS rebinding) is caught, and the socket never re-resolves (#231)."""
+
+    def _conn(self):
+        from openbadgeslib.util import _PinnedHTTPSConnection
+        return _PinnedHTTPSConnection('example.com')
+
+    def test_connect_rejects_private_ip(self):
+        # The rebind case: the pre-check saw a public IP, but at connect the name
+        # now resolves to loopback/metadata — connect() must refuse.
+        conn = self._conn()
+        with patch('openbadgeslib.util._resolve_host', return_value=['127.0.0.1']):
+            with pytest.raises(ValueError, match='SSRF / DNS rebinding'):
+                conn.connect()
+
+    def test_connect_dials_validated_ip_with_hostname_sni(self):
+        conn = self._conn()
+        fake_sock = MagicMock()
+        conn._create_connection = MagicMock(return_value=fake_sock)
+        conn._context = MagicMock()
+        with patch('openbadgeslib.util._resolve_host', return_value=['93.184.216.34']):
+            conn.connect()
+        # Dialed the validated IP, not the hostname (no second resolution).
+        (address, *_), _ = conn._create_connection.call_args
+        assert address == ('93.184.216.34', 443)
+        # TLS SNI / cert verification still use the hostname.
+        _, kwargs = conn._context.wrap_socket.call_args
+        assert kwargs['server_hostname'] == 'example.com'
+
+    def test_connect_allows_private_when_opted_in(self):
+        from openbadgeslib.util import _PinnedHTTPSConnection
+        conn = _PinnedHTTPSConnection('localhost', allow_private=True)
+        conn._create_connection = MagicMock(return_value=MagicMock())
+        conn._context = MagicMock()
+        with patch('openbadgeslib.util._resolve_host', return_value=['127.0.0.1']):
+            conn.connect()   # must not raise
+        (address, *_), _ = conn._create_connection.call_args
+        assert address == ('127.0.0.1', 443)
+
+
+class TestDownloadWallClockDeadline:
+    """A per-socket timeout does not bound total time; download_file enforces a
+    wall-clock budget so a slow-drip server cannot hold the connection (#231)."""
+
+    def test_slow_drip_hits_deadline(self):
+        from openbadgeslib.util import MAX_DOWNLOAD_SECONDS
+        resp = MagicMock()
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        resp.read.return_value = b'x' * 16          # never signals EOF (drip)
+        opener = MagicMock()
+        opener.open.return_value = resp
+        # monotonic(): deadline anchor, then one ok tick, then past the budget.
+        times = iter([0.0, 1.0, MAX_DOWNLOAD_SECONDS + 1.0])
+        with patch('openbadgeslib.util._resolve_host', return_value=['93.184.216.34']), \
+                patch('openbadgeslib.util.request.build_opener', return_value=opener), \
+                patch('openbadgeslib.util.time.monotonic', side_effect=lambda: next(times)):
+            with pytest.raises(ValueError, match='time budget'):
+                download_file('https://example.com/drip')
 
 
 class TestMisc:

--- a/wiki/Stable-API.md
+++ b/wiki/Stable-API.md
@@ -1,0 +1,46 @@
+This page draws the line between the **stable public API** you can rely on across a major version and the **internals** that may change without notice. It is the "public contract" the library freezes for v4 — see [[Upgrading to 4.0]].
+
+The rule of thumb: **if a name is in a package's `__all__`, it is public.** Everything else — any `_underscore` name, any module not listed, any attribute reached through a deep import path that `__all__` does not advertise — is internal and may change in a minor release.
+
+## The stable surface
+
+The top-level `openbadgeslib` package exports an explicit `__all__`. That list *is* the contract:
+
+```python
+import openbadgeslib
+
+openbadgeslib.__all__
+# __version__
+# ob2, ob3, errors                      -> the subpackage entry points
+# OB2Signer, OB2Verifier, OB2VerificationError
+# OB3Signer, OB3Verifier, OB3VerificationError
+# OpenBadgeCredential, Achievement, Issuer
+# KeyFactory, KeyRSA, KeyECC, KeyEd25519
+# issue_from_conf, verify_badge, IssuanceError, SignResult
+```
+
+Notes:
+
+- **Keys.** `KeyEd25519` is a first-class export alongside `KeyRSA` / `KeyECC` — it is the recommended key type for OB 3.0 and the Data Integrity (LDP, `eddsa-rdfc-2022`) proof format.
+- **Subpackages.** `openbadgeslib.ob2` and `openbadgeslib.ob3` each carry their own `__all__` (see [[Python API OB2]] / [[Python API OB3]]). `openbadgeslib.ob3.eudi` (the SD-JWT VC / EUDI track, `[eudi]` extra) is re-exported from `openbadgeslib.ob3`, so `openbadgeslib.ob3.eudi.issue_badge_sd_jwt(...)` needs no deep import. The OB 3.0 Data Integrity signer/verifier are `openbadgeslib.ob3.OB3LdpSigner` / `OB3LdpVerifier`.
+- **Errors.** Every exception the library raises derives from `errors.LibOpenBadgesException`, so `except openbadgeslib.errors.LibOpenBadgesException` catches them all. See [[Keys and Errors]] for the full map.
+- **Facades.** `issue_from_conf` and `verify_badge` are the programmatic "do what the CLI does, but return a result object instead of doing I/O" entry points. They are resolved lazily (a bare `import openbadgeslib` stays lightweight) but are fully part of the contract.
+
+## What is internal
+
+- **Underscore names.** Anything starting with `_` — `openbadgeslib.util._PinnedHTTPSConnection`, `openbadgeslib.confparser.ConfParser` internals, the `_jsonmodel` helpers, `issue._Ob3Context`, etc. These are implementation detail.
+- **Modules not advertised in an `__all__`.** e.g. `openbadgeslib.signer` / `openbadgeslib.verifier` / `openbadgeslib.badge` at the top level are **legacy OpenBadges 1.0 compatibility shims**. They still work (OB 1.0 is supported, no removal planned) and emit a `DeprecationWarning` steering new work to `ob2` / `ob3`, but they are not the modern stable surface. Prefer `openbadgeslib.ob2` / `openbadgeslib.ob3`.
+- **The `ob1` subpackage** is a legacy leaf; do not import from it directly.
+
+## Versioning promise
+
+The library follows [SemVer](https://semver.org/). Within a major version:
+
+- names in a public `__all__` keep working (additions are allowed; removals/renames are not);
+- a removal or a breaking signature change to a public name only happens on a major bump, and is called out in the [Changelog](https://github.com/luisgf/openbadgeslib/blob/master/Changelog.txt) and [[Upgrading to 4.0]].
+
+Internals carry no such promise — pin your dependency and read the changelog if you reach past the public surface.
+
+## The generated API reference
+
+The canonical, always-current API reference is generated from the docstrings with [pdoc](https://pdoc.dev/) and published to GitHub Pages. Because the boundary types are declared (no bare `Any` on `SignResult.credential` / `.assertion`), the reference and your editor's autocompletion show the real types. See [[Guides]] for the link.

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -15,6 +15,7 @@
 
 **Reference**
 - [[CLI Reference]]
+- [[Stable API]]
 - [[Python API OB1]]
 - [[Python API OB2]]
 - [[Python API OB3]]


### PR DESCRIPTION
Implements **every issue in Milestone 5 — "Roadmap R2 · mid term (3-6 months)"** (round-2 architecture / logic / security / coverage pass). Each issue is its own focused commit with a Changelog entry, tests, and a passing local gate.

## Issues

| # | Type | Summary |
|---|------|---------|
| #223 | fix | Move the version-neutral `Badge`/`BadgeImgType` model out of the legacy `ob1` package into `openbadgeslib.badge_model`; OB3 issuance no longer requires the OB1-only `verify_key`/`criteria` (a missing key now surfaces as `IssuanceError`, not a raw `KeyError`). |
| #224 | refactor(errors) | Consolidate the exception hierarchy under `LibOpenBadgesException`: re-anchor `IssuanceError` and `DecompressionLimitExceeded`, add `ConfigError`, retype the signers' unsupported-algorithm error as `UnsupportedAlgorithm` (both also `ValueError` for compat), move the `[logs]` read inside the `try` in `_write_badge_and_log`, add singular aliases. |
| #225 | refactor + feat | Dedupe the shared OB2/OB3 JSON helpers into `openbadgeslib._jsonmodel` (fixing OB2's naive-datetime→local-time timestamp drift); add `load_config()` (raises `ConfigError`, `read_config_or_exit` becomes a thin CLI wrapper), plus typed `IssuerConfig`/`BadgeSectionConfig` dataclasses and a `resolve_key_type()` with centralized defaults. |
| #226 | security(ob3) | SD-JWT VC (EUDI) issuance no longer silently drops `credentialStatus` — it rejects a revocable credential with a clear `EudiError` (the badge would be irrevocable) and now carries `credentialSubject.identifier`; irrevocability documented on the issue/verify docstrings. |
| #227 | security(ob3) | Warn loudly when a revocable badge's status lists are published without a `validUntil` bound (no anti-replay freshness); `PublishResult.no_validity_bound`, surfaced in the CLI + `--json`, and `status_validity_days` documented. |
| #230 | ci | SHA-pin the `id-token: write` actions (PyPI publish + Pages deploy/upload), add `permissions: contents: read` to commit-lint, add a `windows-latest` CI leg + a monkeypatched test of the `fcntl=None` StatusRegistry lock fallback. |
| #231 | security(util) | Pin the SSRF-validated IP on the HTTPS connection (`_PinnedHTTPSConnection`) to defeat DNS rebinding — the check and the socket now share one resolution, for the initial request and every redirect — plus a wall-clock download budget so a slow-drip response can't hold the connection. |
| #232 | refactor | Declare the stable public surface: explicit top-level `__all__`, re-export `KeyEd25519` and the `ob3.eudi` track, type `SignResult.credential`/`.assertion` and `_Ob3Context` with `TYPE_CHECKING` forward refs instead of `Any`, and a new "Stable API" wiki page (freeze prep for v4). |

## Verification

Local gate (matches CI) is green on the full range:

- `flake8 openbadgeslib tests` — clean
- `mypy` (`--strict`) — clean, 43 source files
- `pytest --cov` — **1261 passed**, 93.93% coverage (≥ 93% gate)
- `gitlint --commits origin/master..HEAD` — clean

The DNS-rebinding fix (#231) was additionally verified end-to-end against a real public HTTPS host (TLS SNI/cert OK, GET 200) and a real loopback-resolving name (refused at connect). New tests were added for every issue (`test_errors`, `test_jsonmodel`, `test_confparser`, `test_ob3_publish_cli`, `test_ob3_eudi_sd_jwt`, `test_util`, `test_ob3_status_registry`, `test_public_api`).

## Notes

- The `windows-latest` leg is independent of the publish gate (publish `needs: test`), so a Windows-only quirk never blocks a release.
- `ConfigError` and `UnsupportedAlgorithm` deliberately subclass both `LibOpenBadgesException` and `ValueError`, so existing `except ValueError` callers keep working while `except LibOpenBadgesException` now catches everything.

Closes #223
Closes #224
Closes #225
Closes #226
Closes #227
Closes #230
Closes #231
Closes #232
