### PR TITLE
Document, test & monitor the x5c/eIDAS trust boundary (#236)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,8 +135,12 @@ jobs:
         run: pip show openvc-core | grep '^Version:'
 
       - name: Test the EUDI SD-JWT VC track (isolated) and type-check it
+        # Include the x5c trust-boundary tests: they assert the chain-validation
+        # decisions openbadgeslib delegates to openvc-core (temporal validity,
+        # SAN<->iss binding) and pin the revocation gap, so a drift in the
+        # delegate's behaviour turns this floor/latest job red (#236).
         run: |
-          pytest tests/test_ob3_eudi_sd_jwt.py -v
+          pytest tests/test_ob3_eudi_sd_jwt.py tests/test_ob3_eudi_x5c.py -v
           mypy openbadgeslib/ob3/eudi.py
 
   publish:

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -10,6 +10,18 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
   surfaced, test the fail-closed guards, and speed up batch issuance and
   verification.
 
+  - security(eudi): document and pin the X.509 / eIDAS trust boundary for
+    SD-JWT VC verification. All x5c chain validation is delegated to openvc-core
+    (path building, temporal validity, SAN<->iss binding); openbadgeslib only
+    guarantees the envelope (the x5c header is present, so the anchors are never
+    bypassed by a DID fallback — fail-closed). Crucially, certificate revocation
+    (CRL/OCSP) is NOT checked by either layer — a revoked-but-unexpired leaf
+    still verifies — so a deployment must apply revocation out of band. The
+    division of responsibility is spelled out on `verify_badge_sd_jwt` and the
+    Security Model wiki page; new boundary tests assert openvc-core rejects an
+    expired/not-yet-valid leaf and pin the revocation gap, and the eudi
+    floor/latest CI job now runs them so a drift in the delegate's behaviour
+    turns the build red (#236).
   - security(ob3): with `--check-status`, verify the status list's OWN JWT-VC
     signature by default and bind its issuer to the badge's, so a compromised
     status host can no longer silently un-revoke a credential. The badge's

--- a/openbadgeslib/ob3/eudi.py
+++ b/openbadgeslib/ob3/eudi.py
@@ -293,6 +293,32 @@ def verify_badge_sd_jwt(
       chain is rejected in this mode: the anchors are never bypassed by falling
       back to DID / issuer-URL key resolution. Status is not checked here, as
       with the pinned path.
+
+    X.509 / eIDAS trust boundary — division of responsibility
+    ---------------------------------------------------------
+    In the *x5c_trust_anchors* mode the X.509 trust decision is **delegated to
+    openvc-core** (which builds on ``cryptography``'s ``PolicyBuilder``). This
+    library only guarantees the *envelope*; the chain verdict is not re-asserted
+    here. Concretely:
+
+    * **openbadgeslib guarantees**: the issuer JWT actually carries an ``x5c``
+      header before delegating (:func:`_issuer_jwt_has_x5c`), so the anchors can
+      never be silently bypassed by a DID / issuer-URL fallback (fail-closed);
+      and it surfaces any openvc-core failure as :class:`EudiError`.
+    * **openvc-core guarantees** (asserted by the boundary tests in
+      ``tests/test_ob3_eudi_x5c.py`` against both the pinned and latest release):
+      chain path-validation — signatures, the leaf/intermediate **temporal
+      validity windows** (an expired or not-yet-valid leaf is rejected), name
+      chaining, ``basicConstraints`` — the leaf ``SAN`` ↔ ``iss`` binding, and a
+      P-256 leaf key.
+    * **NOT checked by either** — certificate **revocation (CRL / OCSP)**.
+      ``cryptography``'s path validation does not consult CRL Distribution Points
+      or OCSP, so a leaf that is revoked but still inside its validity window,
+      with an otherwise-valid chain, **will verify**. A deployment that must
+      honour revocation has to obtain it out of band (e.g. the EU Trusted List's
+      own revocation signalling) — do not assume this call applies it. This gap
+      is pinned by a regression test so a future openvc-core that adds revocation
+      is caught by the floor/latest drift job (#236).
     """
     if x5c_trust_anchors is not None:
         return _verify_sd_jwt_x5c(
@@ -338,7 +364,11 @@ def _verify_sd_jwt_x5c(token: str, x5c_trust_anchors: Any, *,
     """Verify a badge SD-JWT whose issuer JWT carries an ``x5c`` chain against
     *x5c_trust_anchors* (X.509 roots), via openvc-core's ``verify_credential``
     pipeline — which path-validates the chain and binds it to ``iss`` before
-    using the leaf key. Returns the underlying ``VerifiedSdJwt``."""
+    using the leaf key. Returns the underlying ``VerifiedSdJwt``.
+
+    See :func:`verify_badge_sd_jwt` for the trust-boundary contract: openvc-core
+    owns the chain verdict (temporal validity, name chaining, SAN↔iss binding);
+    certificate revocation (CRL/OCSP) is NOT checked by either layer (#236)."""
     try:
         from openvc import VerificationPolicy, verify_credential
     except ImportError as exc:

--- a/tests/test_ob3_eudi_x5c.py
+++ b/tests/test_ob3_eudi_x5c.py
@@ -20,11 +20,17 @@ from openbadgeslib.ob3.eudi import (OB3_SD_JWT_VCT, EudiError,
 ISS = 'https://issuer.example'
 _PAST = dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)
 _FUTURE = dt.datetime(2035, 1, 1, tzinfo=dt.timezone.utc)
+# Leaf windows that must land on the wrong side of "now" (the boundary tests).
+_EXPIRED = dt.datetime(2021, 1, 1, tzinfo=dt.timezone.utc)    # not_after in the past
+_NOT_YET = dt.datetime(2034, 1, 1, tzinfo=dt.timezone.utc)    # not_before in the future
 
 
-def _chain():
+def _chain(*, leaf_not_before=_PAST, leaf_not_after=_FUTURE, leaf_crldp=False):
     """Build a root -> intermediate -> leaf chain (leaf SAN = ISS). Returns the
-    x5c list [leaf, inter] (DER-base64), the root cert, and the leaf key."""
+    x5c list [leaf, inter] (DER-base64), the root cert, and the leaf key.
+
+    The leaf's validity window and an optional CRL Distribution Point are
+    parametrised for the trust-boundary tests (#236)."""
     from cryptography import x509
     from cryptography.hazmat.primitives import hashes, serialization
     from cryptography.hazmat.primitives.asymmetric import ec
@@ -33,12 +39,13 @@ def _chain():
     def name(cn):
         return x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)])
 
-    def cert(subject, issuer, issuer_key, subject_key, *, ca, san=None):
+    def cert(subject, issuer, issuer_key, subject_key, *, ca, san=None,
+             not_before=_PAST, not_after=_FUTURE, crldp=False):
         builder = (x509.CertificateBuilder()
                    .subject_name(name(subject)).issuer_name(name(issuer))
                    .public_key(subject_key.public_key())
                    .serial_number(x509.random_serial_number())
-                   .not_valid_before(_PAST).not_valid_after(_FUTURE)
+                   .not_valid_before(not_before).not_valid_after(not_after)
                    .add_extension(x509.BasicConstraints(ca=ca, path_length=None),
                                   critical=True))
         if ca:
@@ -50,6 +57,13 @@ def _chain():
         if san:
             builder = builder.add_extension(
                 x509.SubjectAlternativeName(san), critical=False)
+        if crldp:
+            builder = builder.add_extension(x509.CRLDistributionPoints([
+                x509.DistributionPoint(
+                    full_name=[x509.UniformResourceIdentifier(
+                        'http://crl.example/leaf.crl')],
+                    relative_name=None, reasons=None, crl_issuer=None)]),
+                critical=False)
         return builder.sign(issuer_key, hashes.SHA256())
 
     def der_b64(crt):
@@ -62,7 +76,9 @@ def _chain():
     inter = cert('inter', 'root', root_key, inter_key, ca=True)
     leaf_key = ec.generate_private_key(ec.SECP256R1())
     leaf = cert('leaf', 'inter', inter_key, leaf_key, ca=False,
-                san=[x509.UniformResourceIdentifier(ISS)])
+                san=[x509.UniformResourceIdentifier(ISS)],
+                not_before=leaf_not_before, not_after=leaf_not_after,
+                crldp=leaf_crldp)
     return [der_b64(leaf), der_b64(inter)], root, leaf_key
 
 
@@ -166,6 +182,46 @@ class TestX5cTrust:
         assert _issuer_jwt_has_x5c(token)                   # x5c embedded on issue
         result = verify_badge_sd_jwt(token, x5c_trust_anchors=[root])
         assert result.issuer == ISS                         # verified via anchor
+
+
+class TestX5cTrustBoundary:
+    """Pin the X.509 / eIDAS trust decisions openvc-core owns, and document the
+    revocation gap (#236). These assertions run against BOTH the pinned floor
+    and the latest openvc-core in the `eudi` CI drift job, so a change in the
+    delegate's chain-validation behaviour turns that job red. See the
+    'X.509 / eIDAS trust boundary' section of verify_badge_sd_jwt's docstring.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _needs_openvc(self):
+        pytest.importorskip('openvc')
+
+    def test_expired_leaf_is_rejected(self):
+        # Temporal validity IS enforced by openvc-core (cryptography's
+        # PolicyBuilder .time()): a leaf whose window has closed is refused.
+        x5c, root, leaf_key = _chain(leaf_not_after=_EXPIRED)
+        with pytest.raises(EudiError):
+            verify_badge_sd_jwt(_sd_jwt_with_x5c(leaf_key, x5c),
+                                x5c_trust_anchors=[root])
+
+    def test_not_yet_valid_leaf_is_rejected(self):
+        x5c, root, leaf_key = _chain(leaf_not_before=_NOT_YET)
+        with pytest.raises(EudiError):
+            verify_badge_sd_jwt(_sd_jwt_with_x5c(leaf_key, x5c),
+                                x5c_trust_anchors=[root])
+
+    def test_revocation_is_not_consulted(self):
+        # KNOWN GAP (#236): certificate revocation (CRL / OCSP) is NOT checked —
+        # cryptography's path validation ignores CRL Distribution Points and does
+        # no OCSP. A leaf that carries a CRLDP (the marker of a revocable cert),
+        # is otherwise valid and still inside its window, therefore VERIFIES.
+        # Deployments that must honour revocation obtain it out of band. If a
+        # future openvc-core starts enforcing revocation this assertion flips,
+        # and the floor/latest drift job surfaces it for a contract/doc update.
+        x5c, root, leaf_key = _chain(leaf_crldp=True)
+        result = verify_badge_sd_jwt(_sd_jwt_with_x5c(leaf_key, x5c),
+                                     x5c_trust_anchors=[root])
+        assert result.issuer == ISS   # verified despite the revocation pointer
 
 
 def test_x5c_path_needs_the_extra(monkeypatch):

--- a/wiki/Security-Model.md
+++ b/wiki/Security-Model.md
@@ -175,6 +175,16 @@ Beyond the claim cross-checks, the credential body itself is untrusted input, so
 - **Issuance is fail-closed too**: `OB3LdpSigner` rejects non-Ed25519 keys at construction, refuses to add a second proof to an already-secured document (the verifier would reject the ambiguity), signs only against the bundled context allowlist, and derives the did:key verification method from the *private* key's public half so a stale `public_key` file cannot produce an unverifiable badge. With a did:web issuer the proof names the exact `did:web:…#badge_N` method `openbadges-publish -V 3` publishes.
 - **Status lists stay VC-JWT**: `openbadges-publish -V 3` signs Bitstring Status List credentials as JWT-VCs regardless of the badge's proof format, and `check_status` on a Data Integrity credential consumes them unchanged — the status-bit trust chain is identical for both proof formats.
 
+### X.509 / eIDAS issuer trust (SD-JWT VC) — a delegated trust boundary
+
+The EUDI SD-JWT VC track (`openbadgeslib.ob3.eudi`, the `[eudi]` extra) can anchor issuer trust in **X.509 / an EU Trusted List** instead of a pinned key or a DID: `verify_badge_sd_jwt(token, x5c_trust_anchors=[…roots…])` verifies a badge whose issuer JWT carries an `x5c` certificate chain. This binds it to the eIDAS trust model as the binding EU Trusted List cutover proceeds (TLv6 since 2026‑04). It is important to understand where the trust decision is actually made, because it is **delegated to [openvc-core](https://github.com/luisgf/openvc)** (which builds on `cryptography`'s `PolicyBuilder`):
+
+- **openbadgeslib guarantees the envelope, not the chain verdict.** It confirms the issuer JWT actually carries an `x5c` header before delegating, so the trust anchors can **never be silently bypassed** by a fallback to DID / issuer‑URL key resolution (a `did:jwk`/`did:key` issuer is self‑certifying and would otherwise verify against its own key) — this fails closed. Any openvc‑core failure is surfaced as `EudiError`.
+- **openvc‑core owns the chain verdict:** path validation (signatures, the leaf/intermediate **temporal validity windows**, name chaining, `basicConstraints`), the leaf `SAN` ↔ `iss` binding, and a P‑256 leaf key. openbadgeslib re‑asserts these at the boundary with dedicated tests (`tests/test_ob3_eudi_x5c.py`) that run against **both** the pinned floor and the latest openvc‑core release in CI, so a drift in that external behaviour turns the build red.
+- **Certificate revocation (CRL / OCSP) is NOT checked — by either layer.** `cryptography`'s path validation does not consult CRL Distribution Points or perform OCSP, and openvc‑core adds none. **A leaf that has been revoked but is still inside its validity window, with an otherwise‑valid chain, will verify.** A deployment that must honour revocation has to obtain it out of band (for example the EU Trusted List's own revocation signalling) — do not assume this call applies it. This gap is pinned by a regression test, so a future openvc‑core that starts enforcing revocation is caught by the drift job and prompts a contract/doc update.
+
+Separately, an SD‑JWT VC badge is **irrevocable at the credential level**: `issue_badge_sd_jwt` rejects a credential that carries a `credentialStatus` rather than silently dropping it (SD‑JWT VC status carriage is not wired yet), and both verify paths set `require_status=False`. Revocation of an SD‑JWT VC badge therefore currently rests entirely on the (unchecked, see above) certificate layer.
+
 ## What the signature binds — the assertion, not the image
 
 The signature covers the **assertion / credential** (recipient, achievement, issuer, dates, URLs), **not the bytes of the carrier image**. This is by design in OpenBadges: the embedded assertion is the canonical, verifiable artifact, and a correct consumer reads and validates those signed fields — it does not trust the surrounding pixels.
@@ -190,5 +200,6 @@ Binding the signature to the image bytes (e.g. hashing the pixels into the paylo
 - **Pass the recipient** (`-r` for OB2, `expected_recipient` for OB3) whenever the badge is meant for a specific person; otherwise the binding is your responsibility.
 - **Keep `allow_insecure` off.** Do not downgrade downloads to plain HTTP.
 - **Trust revocation only as far as you trust the issuer host** that serves the `revocationList`.
+- **For SD‑JWT VC / eIDAS `x5c` trust, apply certificate revocation yourself.** `verify_badge_sd_jwt(x5c_trust_anchors=…)` validates the chain and its temporal validity but does **not** consult CRL/OCSP (see the X.509 boundary above) — check revocation against the EU Trusted List out of band before trusting a leaf.
 
 See the [[CLI Reference]] for the exact flags and [[Signing and Verification]] for the end-to-end workflow.


### PR DESCRIPTION
Implements [#236](https://github.com/luisgf/openbadgeslib/issues/236) — making the **X.509 / eIDAS trust boundary** for SD-JWT VC verification explicit, tested, and monitored.

## The problem

`verify_badge_sd_jwt(x5c_trust_anchors=…)` anchors issuer trust in X.509 / an EU Trusted List, but **all** the real chain validation is delegated to openvc-core; `eudi.py` only checks that the `x5c` header is present (to prevent a DID-fallback bypass). The security of the whole eIDAS flow rested on an external dependency whose behaviour was never re-asserted here — and there was no independent check that certificate **revocation** is applied. Relevant as the binding EU Trusted List cutover proceeds (TLv6 since 2026-04).

## What this does

- **Documents the division of responsibility** (on `verify_badge_sd_jwt`'s docstring → pdoc, and a new section on the Security Model wiki page):
  - *openbadgeslib guarantees the envelope* — the `x5c` header is present before delegating, so the anchors are never silently bypassed by a DID/issuer-URL fallback (fail-closed); openvc-core failures surface as `EudiError`.
  - *openvc-core owns the chain verdict* — path validation (signatures, **temporal validity windows**, name chaining, `basicConstraints`), the leaf `SAN` ↔ `iss` binding, P-256 leaf key.
  - **Revocation (CRL/OCSP) is NOT checked by either layer.** `cryptography`'s `PolicyBuilder` consults no CRL/OCSP, so a revoked-but-unexpired leaf still verifies — deployments must apply revocation out of band.
- **Boundary tests** (`tests/test_ob3_eudi_x5c.py`): assert openvc-core rejects an **expired** leaf and a **not-yet-valid** leaf on a known vector, and a regression test that **pins the revocation gap** (a leaf carrying a CRL Distribution Point still verifies) — it flips if a future openvc-core ever enforces revocation.
- **Monitoring**: the `eudi` floor/latest CI drift job now runs the x5c boundary suite, so a change in the delegate's chain-validation behaviour turns the build red.

All three findings were verified empirically against the installed openvc-core 1.18.0 before writing the tests/docs (expired → rejected; not-yet-valid → rejected; CRLDP present → still verifies).

## Verification

- `flake8` + `mypy --strict` clean
- `pytest` — **1264 passed** (3 new boundary tests)
- `gitlint` clean

Not part of the v4.0.0 breaking release (#170) — a standalone security/monitoring hardening, lands on `master` for v3.15.0.

Closes #236


