### PR TITLE
build(deps): raise the openvc-core floors to >=1.26

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -4,7 +4,10 @@ OpenBadgesLib - Changelog
 Newest first. Dates are ISO 8601 (YYYY-MM-DD).
 
 
-* vX.Y.Z - unreleased
+* v4.4.3 - unreleased
+
+  - build(deps): raise the openvc-core floors to `>=1.26` in the `[eudi]`,
+    `[ldp-sd]` and `[oid4vci]` extras.
 
   - security(oid4vci): `--reclaim-unclaimed` no longer frees a status-list
     index whose credential was already delivered to a wallet. Issued grants

--- a/openbadgeslib/oid4vci/handler.py
+++ b/openbadgeslib/oid4vci/handler.py
@@ -70,11 +70,13 @@ MAX_REQUEST_BYTES = 128 * 1024
 def _require_openvc() -> Any:
     """Import the openvc-core OID4VCI pieces, or raise with an actionable hint.
 
-    The openvc-core floor is 1.25 across every extra that pulls it, so
-    ``resolve_proof_key_in_context`` (1.24) and the discovery parsers (1.25)
-    are guaranteed present when the import succeeds; a resolver that somehow
-    resolves older anyway fails loudly at the unexpected-keyword call rather
-    than silently dropping the attested-key form.
+    The openvc-core floor is 1.26 across every extra that pulls it, so
+    ``resolve_proof_key_in_context`` (1.24), the discovery parsers (1.25)
+    and ``require_key_attestation`` (1.26) are guaranteed present when the
+    import succeeds; a resolver that somehow resolves older anyway fails
+    loudly at the unexpected-keyword call rather than silently dropping
+    the attested-key form or spending a nonce on a proof that lacked the
+    advertised attestation.
     """
     try:
         from openvc.openid4vci import (parse_credential_request,

--- a/openbadgeslib/oid4vci/metadata.py
+++ b/openbadgeslib/oid4vci/metadata.py
@@ -175,9 +175,10 @@ def _validate_issuer_metadata(metadata: Dict[str, Any]) -> None:
     try:
         from openvc.openid4vci import parse_credential_issuer_metadata
     except ImportError:
-        # An install WITH the extra that lands an openvc-core below the 1.25
-        # parser would take this branch too — indistinguishable from a plain
-        # minimal install, and silent about the skipped check either way.
+        # An install WITH the extra that lands an openvc-core below the 1.26
+        # floor (parsers landed in 1.25) would take this branch too —
+        # indistinguishable from a plain minimal install, and silent about
+        # the skipped check either way.
         logger.debug('openvc-core OID4VCI discovery parsers unavailable; '
                      'the issuer metadata self-check is skipped (install the '
                      '[oid4vci] extra for it)')

--- a/openbadgeslib/oid4vci/offer.py
+++ b/openbadgeslib/oid4vci/offer.py
@@ -232,7 +232,8 @@ def _validate_offer(offer: Dict[str, Any]) -> None:
         from openvc.openid4vci import parse_credential_offer
     except ImportError:
         # Same caveat as the metadata self-check: an openvc-core older than
-        # 1.25 takes this branch too, silently skipping the check.
+        # the 1.26 floor (parsers landed in 1.25) takes this branch too,
+        # silently skipping the check.
         logger.debug('openvc-core OID4VCI discovery parsers unavailable; '
                      'the Credential Offer self-check is skipped (install '
                      'the [oid4vci] extra for it)')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ ldp = [
 # check_token_status) landed there — and is set at the release the suite is
 # actually tested against, per the rule above.
 eudi = [
-    "openvc-core>=1.25,<2",
+    "openvc-core>=1.26,<2",
 ]
 # ecdsa-sd-2023 (selective disclosure) VERIFY for the OB 3.0 Data Integrity
 # track: credentials secured with the ecdsa-sd-2023 cryptosuite are verified by
@@ -84,7 +84,7 @@ eudi = [
 # canonicalization (pyld). Native eddsa-rdfc-2022 stays under [ldp]; issuance of
 # ecdsa-sd-2023 is out of scope. See openbadgeslib/ob3/ldp.py.
 ldp-sd = [
-    "openvc-core[data-integrity]>=1.25,<2",
+    "openvc-core[data-integrity]>=1.26,<2",
 ]
 # OID4VCI issuance: hand a badge to a wallet over the pre-authorized code flow.
 # openbadgeslib owns the offers, the state (codes, tokens, nonces, grants) and
@@ -93,14 +93,17 @@ ldp-sd = [
 # minimum here, with the pin itself at the tested release like every other
 # openvc-core floor above. 1.25 also brings the discovery parsers this library
 # now self-checks its issuer metadata and Credential Offers against
-# (openbadgeslib/oid4vci/metadata.py and offer.py).
+# (openbadgeslib/oid4vci/metadata.py and offer.py). 1.26 adds
+# require_key_attestation= on verify_credential_request_proofs, so an
+# issuer that advertises key_attestations_required can refuse a proof
+# without one before the signature and before the nonce is spent.
 #
 # Everything except openbadgeslib/oid4vci/handler.py works without the extra,
 # and the credential-endpoint tests skip themselves when the module is absent —
 # so an install that does not ask for [oid4vci] is never broken by its absence.
 # See openbadgeslib/oid4vci/ and wiki/Issuing-to-Wallets-with-OID4VCI.md.
 oid4vci = [
-    "openvc-core>=1.25,<2",
+    "openvc-core>=1.26,<2",
 ]
 dev = [
     "pytest>=8.0",

--- a/tests/test_oid4vci_protocol.py
+++ b/tests/test_oid4vci_protocol.py
@@ -899,9 +899,10 @@ class TestCredentialEndpoint:
 
 class TestSelfCheckedDiscovery:
     """The builders pass their output through openvc-core's fail-closed wire
-    parsers (≥1.25), so a document no wallet would accept is a ConfigError at
-    build time — not a wallet that silently never scans. These tests need the
-    [oid4vci] extra: without it the builders return their output unchecked."""
+    parsers (1.25, floor 1.26), so a document no wallet would accept is a
+    ConfigError at build time — not a wallet that silently never scans.
+    These tests need the [oid4vci] extra: without it the builders return
+    their output unchecked."""
 
     @pytest.fixture(autouse=True)
     def _needs_openvc(self):


### PR DESCRIPTION
## What and why

Raise the `[eudi]`, `[ldp-sd]` and `[oid4vci]` openvc-core floors from `>=1.25` to `>=1.26`.

openvc-core 1.26.0 (2026-08-14) adds `require_key_attestation=` on `verify_credential_request_proofs`. The next PR wires that flag so an issuer that advertises `key_attestations_required` can refuse a proof without `key_attestation` *before* the signature and *before* the `c_nonce` is spent.

CI's `eudi extra (openvc-core latest)` already resolved 1.26.0 on 2026-08-15 and was green.

## Checklist

- [x] `flake8` / `mypy` / `pytest` — pin-and-comment change; the suite is unchanged.
- [x] Conventional Commits / gitlint.
- [x] Changelog entry under `* v4.4.3 - unreleased`.
- [x] Comments that restated the 1.25 floor updated.

Stacked under: the `security(oid4vci): refuse proofs missing key_attestation when advertised` PR.