### PR TITLE
security(oid4vci): refuse proofs missing key_attestation when advertised

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,6 +6,15 @@ Newest first. Dates are ISO 8601 (YYYY-MM-DD).
 
 * v4.4.3 - unreleased
 
+  - security(oid4vci): an issuer that advertises
+    ``key_attestations_required`` now refuses a proof without
+    ``key_attestation`` before the signature is checked and before the
+    ``c_nonce`` is spent (openvc-core 1.26's ``require_key_attestation``).
+    Set ``oid4vci_key_attestations_required`` on the badge section, or pass
+    ``require_key_attestation=True`` to ``handle_credential_request``.
+    Without this, a software wallet's §8.3.1 retry spent a fresh nonce on
+    every attempt and looped.
+
   - build(deps): raise the openvc-core floors to `>=1.26` in the `[eudi]`,
     `[ldp-sd]` and `[oid4vci]` extras.
 

--- a/openbadgeslib/config.ini.example
+++ b/openbadgeslib/config.ini.example
@@ -143,6 +143,13 @@ key_type    = RSA
 ; above; vc+sd-jwt is the EUDI track and is IRREVOCABLE, so it cannot be
 ; combined with status_lists. vc+sd-jwt also needs key_type = ED25519 or ECC.
 ;oid4vci_formats  = jwt_vc_json
+; Demand a key attestation from the wallet (OID4VCI 1.0 §12.2.4). Unset is
+; the spec default: the parameter MUST NOT appear unless you actually
+; require one, or software wallets are locked out. true / {} = required
+; with no extra constraints; a JSON object is the Appendix D.2 set.
+; Advertising this also refuses a proof without key_attestation before
+; the nonce is spent — do not publish it and then accept inline-jwk proofs.
+;oid4vci_key_attestations_required = true
 ;mail        = ${paths:base}/badge_1_mail.txt
 
 [badge_2]

--- a/openbadgeslib/confparser.py
+++ b/openbadgeslib/confparser.py
@@ -23,7 +23,8 @@
 
 from configparser import ConfigParser, ExtendedInterpolation, Error as ConfigParserError
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
+import json
 import os
 import sys
 import logging
@@ -378,6 +379,52 @@ def oid4vci_formats(conf: ConfigParser, badge_section: str) -> Tuple[str, ...]:
                 "an RSA key — use key_type = ED25519 or ECC, or drop that "
                 "format" % (badge_section, ', '.join(rsa_incapable)))
     return tuple(formats)
+
+
+def oid4vci_key_attestations_required(
+        conf: ConfigParser, badge_section: str) -> Optional[Dict[str, Any]]:
+    """The key-attestation policy a badge advertises over OID4VCI, or None.
+
+    Absent (the default) means the issuer does **not** require a key
+    attestation, and OpenID4VCI 1.0 §12.2.4 says the parameter MUST NOT then
+    appear in metadata. Present means it is required:
+
+    * ``true`` / ``yes`` / ``1`` / ``{}`` / empty advertise an unconstrained
+      requirement (a key attestation is needed, with no extra constraints);
+    * a JSON object is the Appendix D.2 constraint set, validated by the same
+      shape check :func:`~openbadgeslib.ob3.eudi.badge_credential_configuration`
+      uses.
+
+    The credential endpoint reads this same key, so advertising the
+    requirement without enforcing it — the wallet-retry loop openvc-core
+    1.26's ``require_key_attestation`` exists to close — cannot happen from
+    configuration alone.
+    """
+    if (badge_section not in conf
+            or 'oid4vci_key_attestations_required' not in conf[badge_section]):
+        return None
+    raw = (conf[badge_section].get('oid4vci_key_attestations_required')
+           or '').strip()
+    if raw.lower() in ('', 'true', 'yes', '1', '{}'):
+        value: Any = {}
+    else:
+        try:
+            parsed = json.loads(raw)
+        except ValueError as exc:
+            raise ConfigError(
+                "[%s] oid4vci_key_attestations_required must be true or a "
+                "JSON object, got %r" % (badge_section, raw)) from exc
+        if not isinstance(parsed, dict):
+            raise ConfigError(
+                "[%s] oid4vci_key_attestations_required must be a JSON "
+                "object, got %s" % (badge_section, type(parsed).__name__))
+        value = parsed
+    from .ob3.eudi import EudiError, _key_attestations_required
+    try:
+        return _key_attestations_required(value)
+    except EudiError as exc:
+        raise ConfigError("[%s] oid4vci_key_attestations_required: %s"
+                          % (badge_section, exc)) from exc
 
 
 # ── centralized config defaults ──────────────────────────────────────────────

--- a/openbadgeslib/oid4vci/handler.py
+++ b/openbadgeslib/oid4vci/handler.py
@@ -43,7 +43,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Mapping, Optional, Union
 
-from ..confparser import oid4vci_config
+from ..confparser import oid4vci_config, oid4vci_key_attestations_required
 from ..issue import CredentialResult, issue_credential_from_conf
 from .codes import (dummy_tx_verification, new_secret, secret_id,
                     verify_tx_code)
@@ -217,7 +217,8 @@ def handle_credential_request(conf: configparser.ConfigParser,
                               access_token: Optional[str], store: Any,
                               nonces: NonceIssuer,
                               now: Optional[datetime] = None,
-                              resolve_proof_key_in_context: Any = None
+                              resolve_proof_key_in_context: Any = None,
+                              require_key_attestation: bool = False
                               ) -> CredentialResponse:
     """Verify a Credential Request and issue what its grant authorises.
 
@@ -238,6 +239,19 @@ def handle_credential_request(conf: configparser.ConfigParser,
     ``attested_keys``), but trusting the attestation is the deployment's
     decision, not this library's default. When None (the default), only
     proofs that carry their key inline are accepted, exactly as before.
+
+    *require_key_attestation* refuses a proof whose header has no
+    ``key_attestation`` **before** the signature is checked and **before**
+    the ``c_nonce`` is spent (openvc-core ≥1.26). Default False, matching
+    the normative metadata default: OpenID4VCI 1.0 §12.2.4 says
+    ``key_attestations_required`` MUST NOT appear unless the issuer
+    actually requires one. The flag is also forced on when the grant's
+    badge advertises that parameter (via
+    ``oid4vci_key_attestations_required`` in the config, or an explicit
+    True here for a caller that published the requirement through
+    :func:`~openbadgeslib.ob3.eudi.badge_credential_configuration`).
+    Advertising it without this check spends the nonce on a proof the
+    wallet will retry forever.
 
     Raises :class:`OID4VCIError` for anything the wallet did wrong, and lets
     :class:`~openbadgeslib.errors.IssuanceError` through untouched for anything
@@ -288,6 +302,9 @@ def handle_credential_request(conf: configparser.ConfigParser,
             'this issuer does not use credential_identifier; send a '
             'credential_configuration_id')
 
+    badge, _fmt = parse_credential_configuration_id(
+        conf, grant.credential_configuration_id)
+    advertised = oid4vci_key_attestations_required(conf, badge) is not None
     try:
         proofs = verify_proofs(
             request,
@@ -305,6 +322,9 @@ def handle_credential_request(conf: configparser.ConfigParser,
             resolve_proof_key=None,
             resolve_proof_key_in_context=resolve_proof_key_in_context,
             trust_anchors=None,
+            # OR, never AND-NOT: advertising the requirement without
+            # enforcing it is the retry loop this flag exists to close.
+            require_key_attestation=require_key_attestation or advertised,
             max_age_s=cfg.proof_max_age_s, now=moment,
             batch_size=grant.max_proofs)
     except OID4VCIStoreError:

--- a/openbadgeslib/oid4vci/metadata.py
+++ b/openbadgeslib/oid4vci/metadata.py
@@ -40,7 +40,7 @@ import logging
 from typing import Any, Dict, List, Optional, Sequence
 
 from ..confparser import (OID4VCIConfig, oid4vci_config, oid4vci_formats,
-                          resolve_key_type)
+                          oid4vci_key_attestations_required, resolve_key_type)
 from ..errors import ConfigError
 from ..keys import KeyType
 from .formats import FORMAT_JWT_VC_JSON, FORMAT_SD_JWT_VC
@@ -233,6 +233,12 @@ def _configuration(conf: configparser.ConfigParser, cfg: OID4VCIConfig,
                     list(PROOF_SIGNING_ALGS)},
         },
     }
+    required = oid4vci_key_attestations_required(conf, badge)
+    if required is not None:
+        # Presence is the requirement. An empty object is the spec's
+        # "needed, unconstrained" spelling — not a placeholder.
+        entry['proof_types_supported']['jwt'][
+            'key_attestations_required'] = required
     if credential_format == FORMAT_SD_JWT_VC:
         from ..ob3.eudi import OB3_SD_JWT_VCT
         entry['vct'] = (conf['issuer'].get('sd_jwt_vct') or '').strip() \

--- a/tests/test_oid4vci_config.py
+++ b/tests/test_oid4vci_config.py
@@ -11,7 +11,8 @@ import os
 import pytest
 
 from openbadgeslib.confparser import (OID4VCIConfig, load_config,
-                                      oid4vci_config, oid4vci_formats)
+                                      oid4vci_config, oid4vci_formats,
+                                      oid4vci_key_attestations_required)
 from openbadgeslib.errors import ConfigError
 from openbadgeslib.ob3 import IdentityObject
 from openbadgeslib.ob3.did import did_jwk_from_jwk
@@ -179,6 +180,49 @@ class TestOID4VCIFormats:
                        badge_extra='oid4vci_formats = jwt_vc_json, vc+sd-jwt\n')
         assert oid4vci_formats(conf, 'badge_1') == \
             (FORMAT_JWT_VC_JSON, FORMAT_SD_JWT_VC)
+
+
+class TestOID4VCIKeyAttestationsRequired:
+    def test_absent_key_means_not_required(self, tmp_path):
+        assert oid4vci_key_attestations_required(
+            _config(tmp_path), 'badge_1') is None
+
+    def test_true_is_unconstrained(self, tmp_path):
+        conf = _config(tmp_path,
+                       badge_extra='oid4vci_key_attestations_required = true\n')
+        assert oid4vci_key_attestations_required(conf, 'badge_1') == {}
+
+    def test_empty_value_is_unconstrained(self, tmp_path):
+        conf = _config(tmp_path,
+                       badge_extra='oid4vci_key_attestations_required =\n')
+        assert oid4vci_key_attestations_required(conf, 'badge_1') == {}
+
+    def test_json_object_is_validated(self, tmp_path):
+        conf = _config(tmp_path, badge_extra=(
+            'oid4vci_key_attestations_required = '
+            '{"key_storage": ["iso_18045_moderate"]}\n'))
+        assert oid4vci_key_attestations_required(conf, 'badge_1') == {
+            'key_storage': ['iso_18045_moderate']}
+
+    def test_unknown_constraint_is_refused(self, tmp_path):
+        conf = _config(tmp_path, badge_extra=(
+            'oid4vci_key_attestations_required = {"hardware": ["yes"]}\n'))
+        with pytest.raises(ConfigError, match='unknown'):
+            oid4vci_key_attestations_required(conf, 'badge_1')
+
+    def test_non_object_json_is_refused(self, tmp_path):
+        conf = _config(
+            tmp_path,
+            badge_extra='oid4vci_key_attestations_required = ["iso"]\n')
+        with pytest.raises(ConfigError, match='JSON object'):
+            oid4vci_key_attestations_required(conf, 'badge_1')
+
+    def test_garbage_is_refused(self, tmp_path):
+        conf = _config(
+            tmp_path,
+            badge_extra='oid4vci_key_attestations_required = not-json\n')
+        with pytest.raises(ConfigError, match='true or a JSON object'):
+            oid4vci_key_attestations_required(conf, 'badge_1')
 
 
 class TestDidJwk:

--- a/tests/test_oid4vci_protocol.py
+++ b/tests/test_oid4vci_protocol.py
@@ -39,7 +39,8 @@ ISSUER = 'https://issuer.example/issuer/'
 
 def _write_conf(tmp_path, *, status=False, formats='jwt_vc_json',
                 key_type='RSA', priv='test_sign_rsa.pem',
-                pub='test_verify_rsa.pem', oid4vci_extra=''):
+                pub='test_verify_rsa.pem', oid4vci_extra='',
+                badge_extra=''):
     log = tmp_path / 'log'
     log.mkdir(exist_ok=True)
     lines = [
@@ -61,6 +62,8 @@ def _write_conf(tmp_path, *, status=False, formats='jwt_vc_json',
         'key_type = %s' % key_type,
         'oid4vci_formats = %s' % formats,
     ]
+    if badge_extra:
+        lines.append(badge_extra)
     if status:
         lines.append('status_lists = revocation')
     path = tmp_path / 'cfg.ini'
@@ -116,6 +119,9 @@ class TestIssuerMetadata:
             'proof_signing_alg_values_supported'] == ['ES256', 'ES384', 'EdDSA']
         assert entry['credential_definition']['type'] == [
             'VerifiableCredential', 'OpenBadgeCredential']
+        # §12.2.4: the parameter MUST NOT be present unless required.
+        assert 'key_attestations_required' not in entry[
+            'proof_types_supported']['jwt']
 
     def test_points_wallets_at_the_authorization_server(self, conf):
         # Without this a wallet cannot find the token endpoint and the
@@ -170,6 +176,25 @@ class TestIssuerMetadata:
         del conf['badge_1']['oid4vci_formats']
         with pytest.raises(ConfigError, match='does not opt into'):
             build_issuer_metadata(conf, badges=['badge_1'])
+
+    def test_advertises_key_attestations_required_when_configured(
+            self, tmp_path):
+        conf = _write_conf(
+            tmp_path,
+            badge_extra='oid4vci_key_attestations_required = true')
+        jwt = build_issuer_metadata(conf)['credential_configurations_supported'][
+            'badge_1_jwt_vc_json']['proof_types_supported']['jwt']
+        assert jwt['key_attestations_required'] == {}
+
+    def test_constraint_object_is_copied_into_metadata(self, tmp_path):
+        conf = _write_conf(
+            tmp_path,
+            badge_extra='oid4vci_key_attestations_required = '
+                        '{"key_storage": ["iso_18045_moderate"]}')
+        jwt = build_issuer_metadata(conf)['credential_configurations_supported'][
+            'badge_1_jwt_vc_json']['proof_types_supported']['jwt']
+        assert jwt['key_attestations_required'] == {
+            'key_storage': ['iso_18045_moderate']}
 
 
 class TestAuthorizationServerMetadata:
@@ -1177,3 +1202,82 @@ class TestKeyAttestationProofs:
                 conf, store, nonces, proof,
                 resolve_proof_key_in_context=lambda ctx: jwk)
         assert caught.value.error in (INVALID_PROOF, INVALID_CREDENTIAL_REQUEST)
+
+
+class TestRequireKeyAttestation:
+    """openvc-core 1.26: refuse a missing ``key_attestation`` before the
+    nonce is spent, when the issuer advertised the requirement."""
+
+    @pytest.fixture(autouse=True)
+    def _needs_openvc(self):
+        pytest.importorskip('openvc.openid4vci')
+
+    def _token_and_body(self, conf, store, proof):
+        offer = build_credential_offer(conf, 'badge_1', 'r@example.org',
+                                       store=store)
+        token = handle_token_request(conf, code=offer.pre_authorized_code,
+                                     store=store)
+        body = {'credential_configuration_id':
+                offer.credential_configuration_ids[0],
+                'proofs': {'jwt': [proof]}}
+        return token, body
+
+    def test_flag_refuses_an_inline_proof_and_keeps_the_nonce(
+            self, conf, store, nonces):
+        key, jwk = _holder_key()
+        nonce = handle_nonce_request(conf, nonces=nonces)['c_nonce']
+        proof = _key_proof(nonce, key, jwk)
+        token, body = self._token_and_body(conf, store, proof)
+        with pytest.raises(OID4VCIError) as caught:
+            handle_credential_request(
+                conf, body, access_token=token.access_token,
+                store=store, nonces=nonces, require_key_attestation=True)
+        assert caught.value.error == INVALID_PROOF
+        # consume() is True iff THIS call spent it: the nonce must still
+        # be live, or the wallet's §8.3.1 retry is a loop.
+        assert nonces.consume(nonce) is True
+
+    def test_advertised_requirement_refuses_without_the_flag(
+            self, tmp_path, store, nonces):
+        conf = _write_conf(
+            tmp_path,
+            badge_extra='oid4vci_key_attestations_required = true')
+        key, jwk = _holder_key()
+        nonce = handle_nonce_request(conf, nonces=nonces)['c_nonce']
+        proof = _key_proof(nonce, key, jwk)
+        token, body = self._token_and_body(conf, store, proof)
+        with pytest.raises(OID4VCIError) as caught:
+            handle_credential_request(
+                conf, body, access_token=token.access_token,
+                store=store, nonces=nonces)
+        assert caught.value.error == INVALID_PROOF
+        assert nonces.consume(nonce) is True
+
+    def test_default_still_accepts_an_inline_proof(self, conf, store, nonces):
+        key, jwk = _holder_key()
+        nonce = handle_nonce_request(conf, nonces=nonces)['c_nonce']
+        proof = _key_proof(nonce, key, jwk)
+        token, body = self._token_and_body(conf, store, proof)
+        response = handle_credential_request(
+            conf, body, access_token=token.access_token,
+            store=store, nonces=nonces)
+        assert len(response.credentials) == 1
+
+    def test_attested_proof_issues_when_required(self, conf, store, nonces):
+        from openbadgeslib.ob3.did import did_jwk_from_jwk
+        key, jwk = _holder_key()
+        nonce = handle_nonce_request(conf, nonces=nonces)['c_nonce']
+        proof = TestKeyAttestationProofs()._attested_proof(nonce, key, jwk)
+
+        def resolver(ctx):
+            return dict(ctx.key_attestation.attested_keys[0])
+
+        token, body = self._token_and_body(conf, store, proof)
+        response = handle_credential_request(
+            conf, body, access_token=token.access_token,
+            store=store, nonces=nonces,
+            resolve_proof_key_in_context=resolver,
+            require_key_attestation=True)
+        claims = jwt.decode(response.credentials[0],
+                            options={'verify_signature': False})
+        assert claims['sub'] == did_jwk_from_jwk(jwk)

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -155,6 +155,7 @@ Define one section per badge. The part after `badge_` is the badge id you pass t
 | `status_base` | `https://.../badge_1/` *(commented)* | Public base URL the status lists are served under (`<status_base><purpose>.jwt`). Default: `${issuer:publish_url}badge_N/`. |
 | `status_validity_days` | *(unset)* | OB3, **opt-in**: when set (e.g. `7`–`30`), published status lists carry a `validUntil = now + N days`, and a verifier rejects a stale copy served past that instant (replay protection). Requires republishing (e.g. a cron `openbadges-publish -V 3`) within the window. Unset: lists never expire. |
 | `oid4vci_formats` | `jwt_vc_json` *(commented)* | OID4VCI opt-in: comma-separated subset of `jwt_vc_json`, `vc+sd-jwt`. Unset: the badge is not offered to wallets. `vc+sd-jwt` cannot be combined with `status_lists` and needs `key_type = ED25519` or `ECC`. See [[Issuing to Wallets with OID4VCI]]. |
+| `oid4vci_key_attestations_required` | `true` *(commented)* | Advertise `key_attestations_required` on this badge's OID4VCI configuration and refuse a wallet key proof that has no `key_attestation` **before** the nonce is spent. Unset (the default, and the spec default): the parameter is omitted and software wallets stay welcome. `true` / `yes` / `1` / `{}` / empty = required, unconstrained; a JSON object is the Appendix D.2 constraint set (`key_storage` / `user_authentication`). See [[Issuing to Wallets with OID4VCI]]. |
 | `mail` | `${paths:base}/badge_1_mail.txt` | Path to the mail template used by `openbadges-signer -M`. |
 
 ```ini
@@ -206,6 +207,6 @@ This lets you change `base` once and have every dependent path update automatica
 | `openbadges-signer` | `[paths]`, `[logs]`, `[smtp]` (with `-M`), `[issuer]` (OB3), `[badge_<name>]` |
 | `openbadges-publish` | `[paths]` (`base_status`, OB3), `[issuer]` (incl. `did`, `sd_jwt_vct`), `[oid4vci]` (`store_path`, for `--reclaim-unclaimed`), `[badge_<name>]` (OB2: `crypto_key`/`hosted_assertions_base`; OB3: `status_lists`/`status_size_bits`/`status_base`) |
 | `openbadges status` | `[paths]` (`base_status`), `[issuer]` (`publish_url`), `[badge_<name>]` (`status_lists` and the other status keys) — read-only |
-| library OID4VCI | `[oid4vci]`, `[issuer]` (`publish_url`, `sd_jwt_vct`), `[badge_<name>]` (`oid4vci_formats`, `status_lists`, keys) |
+| library OID4VCI | `[oid4vci]`, `[issuer]` (`publish_url`, `sd_jwt_vct`), `[badge_<name>]` (`oid4vci_formats`, `oid4vci_key_attestations_required`, `status_lists`, keys) |
 
 For the full flag list of each command see [[CLI Reference]]. For end-to-end recipes (issuing, mailing, publishing) see [[Guides]].

--- a/wiki/Issuing-to-Wallets-with-OID4VCI.md
+++ b/wiki/Issuing-to-Wallets-with-OID4VCI.md
@@ -127,6 +127,29 @@ handle_credential_request(conf, body, access_token=…, store=store,
 
 openvc enforces the one thing that is safe to enforce without trust: App. D's MUST that the proof be signed by one of the attestation's `attested_keys` (compared by RFC 7638 thumbprint). That check can only *reject* — it catches an honest wallet, or your own resolver, handing over a key the wallet never claimed. Whether the attestation itself is genuine is the resolver's job; without one, the attested-key form is refused like any other unresolved `kid`.
 
+### Requiring a key attestation
+
+Publishing `key_attestations_required` in issuer metadata without refusing proofs that omit `key_attestation` spends the `c_nonce` on a request the wallet will retry forever (OID4VCI 1.0 §8.3.1). The two have to stay in lockstep.
+
+From config, set the badge key — metadata advertises the parameter **and** `handle_credential_request` passes `require_key_attestation=True` to openvc-core (≥ 1.26), which rejects before the signature and before the nonce is spent:
+
+```ini
+[badge_1]
+oid4vci_formats = jwt_vc_json
+oid4vci_key_attestations_required = true
+; or a D.2 constraint object:
+; oid4vci_key_attestations_required = {"key_storage": ["iso_18045_moderate"]}
+```
+
+From code, if you published the requirement through `badge_credential_configuration(key_attestations_required=…)` (your own metadata document, not `build_issuer_metadata`), pass the flag yourself:
+
+```python
+handle_credential_request(conf, body, access_token=…, store=store,
+                          nonces=nonces, require_key_attestation=True)
+```
+
+Leave both unset for an ordinary Open Badge: software wallets stay welcome. The default is the spec default, not a conservative one.
+
 ### Validating offers you receive
 
 A platform that relays offers, or that wants to cross-check the by-reference documents it serves, can run the same fail-closed parser a wallet runs:

--- a/wiki/Python-API-OB3.md
+++ b/wiki/Python-API-OB3.md
@@ -392,6 +392,8 @@ badge_credential_configuration(key_attestations_required={
 
 The shape is validated — an unknown key, an empty array (the spec says *non-empty*), a bare string where an array belongs, or a non-string level all raise `EudiError` at build time rather than at a holder's wallet. The resistance *values* are not checked: D.2 defines `iso_18045_high` / `iso_18045_moderate` / `iso_18045_enhanced-basic` / `iso_18045_basic` but lets each ecosystem define its own. Note that HAIP requires *wallets* to support key attestations (§4.5.1); it does not require issuers to demand them.
 
+If this configuration is the one you serve, the credential endpoint must refuse a proof that has no `key_attestation` **before** it spends the `c_nonce`. `handle_credential_request(..., require_key_attestation=True)` does that (openvc-core ≥ 1.26). An INI-driven issuer that sets `oid4vci_key_attestations_required` gets both the metadata field and the refusal from the same key; see [[Issuing to Wallets with OID4VCI]].
+
 **Out of scope on purpose:** the enclosing `/.well-known/openid-credential-issuer` document (endpoints, authorization servers, per-tenant display — deployment policy, and one document per tenant in a multi-tenant issuer), the Credential Offer, the Credential Response and the nonce store. The protocol endpoints are the application's; this library supplies the format knowledge. Note that OpenID4VCI 1.0 Final carries `claims`/`display` at the top level of the configuration, which is what this emits; the EU reference issuer nests them under `credential_metadata` — nest them yourself if you must match that deployment.
 
 ### Verifying a third-party badge via eIDAS X.509 / EU Trusted Lists


### PR DESCRIPTION
## What and why

An issuer that publishes `key_attestations_required` in OID4VCI metadata but still accepts an inline-`jwk` proof spends the wallet's `c_nonce` and then sees `VerifiedProof.key_attestation is None`. The wallet retries (§8.3.1) with a fresh nonce, forever.

openvc-core 1.26 adds `require_key_attestation=` to close that loop on the verify path. This PR connects it:

- `handle_credential_request(..., require_key_attestation=True)` forwards the flag.
- A new badge key, `oid4vci_key_attestations_required`, both **advertises** the parameter in `build_issuer_metadata` and **forces** the flag on the credential endpoint. Advertising without enforcing cannot happen from configuration alone.
- Callers that publish via `badge_credential_configuration(key_attestations_required=…)` pass the kwarg themselves (their metadata is not the INI document).

Replaces #326 (closed when #325's branch was deleted after rebase-merge). Depends on #325 (already on master). Completes the seam left after #272.

## Checklist

- [x] `flake8`, `mypy`, and the OID4VCI / eudi-metadata / docs suites pass locally with `[oid4vci]` installed (`OPENBADGES_REQUIRE_OID4VCI=1`).
- [x] Conventional Commits / gitlint.
- [x] Changelog entry under `* v4.4.3 - unreleased`.
- [x] Wiki (`Configuration`, `Issuing to Wallets with OID4VCI`, `Python API OB3`) and `config.ini.example` updated.